### PR TITLE
ARQ-936 Clean up poms for arquillian.org consumption

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,11 +2,13 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>arquillian-warp-parent</artifactId>
         <groupId>org.jboss.arquillian.extension</groupId>
+        <artifactId>arquillian-warp-parent</artifactId>
         <version>1.0.0.Alpha1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>arquillian-warp-api</artifactId>
+    <name>Arquillian Warp Extension: API</name>
+
 </project>

--- a/extension/phaser-ftest/pom.xml
+++ b/extension/phaser-ftest/pom.xml
@@ -4,42 +4,42 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>arquillian-warp-parent</artifactId>
         <groupId>org.jboss.arquillian.extension</groupId>
+        <artifactId>arquillian-warp-parent</artifactId>
         <version>1.0.0.Alpha1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>arquillian-warp-phaser-ftest</artifactId>
-
-    <properties>
-        <version.org.jboss.jbossas>7.1.1.Final</version.org.jboss.jbossas>
-    </properties>
+    <name>Arquillian Warp Extension: Phaser Tests</name>
 
     <dependencies>
 
         <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>pom</type>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-warp-impl</artifactId>
-            <version>1.0.0.Alpha1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-warp-phaser</artifactId>
-            <version>1.0.0.Alpha1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-            
+
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
@@ -50,30 +50,29 @@
             <artifactId>arquillian-protocol-servlet</artifactId>
             <scope>test</scope>
         </dependency>
-    
+
         <!-- JUnit -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
             <scope>test</scope>
         </dependency>
-        
+
         <!-- ShrinkWrap resolver -->
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api</artifactId>
-            <version>${version.shrinkwrap-resolver}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-            <version>${version.shrinkwrap-resolver}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <version>${version.shrinkwrap-resolver}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -83,37 +82,17 @@
             <scope>test</scope>
         </dependency>
 
-
-
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>
             <id>jbossas-remote-7</id>
             <dependencies>
                 <dependency>
-                    <groupId>org.jboss.spec</groupId>
-                    <artifactId>jboss-javaee-6.0</artifactId>
-                    <version>1.0.0.Final</version>
-                    <type>pom</type>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-remote</artifactId>
                     <version>${version.org.jboss.jbossas}</version>
+                    <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>

--- a/extension/phaser-ftest/src/main/java/org/jboss/as/quickstarts/jsf/RichBean.java
+++ b/extension/phaser-ftest/src/main/java/org/jboss/as/quickstarts/jsf/RichBean.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
-import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 
 /**

--- a/extension/phaser/pom.xml
+++ b/extension/phaser/pom.xml
@@ -3,30 +3,29 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>arquillian-warp-parent</artifactId>
         <groupId>org.jboss.arquillian.extension</groupId>
+        <artifactId>arquillian-warp-parent</artifactId>
         <version>1.0.0.Alpha1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>arquillian-warp-phaser</artifactId>
+    <name>Arquillian Warp Extension: Phaser</name>
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.jboss.spec.javax.faces</groupId>
             <artifactId>jboss-jsf-api_2.1_spec</artifactId>
-            <version>2.0.2.Final</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.el</groupId>
             <artifactId>jboss-el-api_2.2_spec</artifactId>
-            <version>1.0.1.Final</version>
             <scope>provided</scope>
         </dependency>
 
@@ -37,7 +36,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-warp-spi</artifactId>
-            <version>1.0.0.Alpha1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/extension/phaser/src/main/java/org/jboss/arquillian/warp/extension/phaser/extension/PhaserExtension.java
+++ b/extension/phaser/src/main/java/org/jboss/arquillian/warp/extension/phaser/extension/PhaserExtension.java
@@ -1,7 +1,7 @@
 package org.jboss.arquillian.warp.extension.phaser.extension;
 
 import org.jboss.arquillian.core.spi.LoadableExtension;
-import org.jboss.arquillian.warp.extension.phaser.PhaserListener;
+import org.jboss.arquillian.warp.extension.phaser.Phase;
 import org.jboss.arquillian.warp.spi.WarpLifecycleExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -16,7 +16,7 @@ public class PhaserExtension implements LoadableExtension, WarpLifecycleExtensio
 
     @Override
     public JavaArchive getEnrichmentLibrary() {
-        return ShrinkWrap.create(JavaArchive.class, "warp-extension-phaser.jar").addPackage(PhaserListener.class.getPackage())
+        return ShrinkWrap.create(JavaArchive.class, "warp-extension-phaser.jar").addPackage(Phase.class.getPackage())
                 .addAsManifestResource("META-INF/warp-extensions/faces-config.xml", "faces-config.xml");
     }
 

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -3,23 +3,24 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>arquillian-warp-parent</artifactId>
         <groupId>org.jboss.arquillian.extension</groupId>
+        <artifactId>arquillian-warp-parent</artifactId>
         <version>1.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 
     <artifactId>arquillian-warp-ftest</artifactId>
-    
-    <properties>
-        <version.org.jboss.jbossas>7.1.1.Final</version.org.jboss.jbossas>
-    </properties>
+    <name>Arquillian Warp Extension: Tests</name>
 
     <dependencies>
-
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-warp-impl</artifactId>
-            <version>1.0.0.Alpha1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -45,7 +46,7 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
 
     <profiles>
@@ -53,20 +54,14 @@
             <id>jbossas-remote-7</id>
             <dependencies>
                 <dependency>
-                    <groupId>org.jboss.spec</groupId>
-                    <artifactId>jboss-javaee-6.0</artifactId>
-                    <version>1.0.0.Final</version>
-                    <type>pom</type>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-remote</artifactId>
                     <version>${version.org.jboss.jbossas}</version>
+                    <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>
-        
+
         <profile>
             <id>jbossas-managed-7</id>
             <activation>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -10,6 +11,7 @@
     </parent>
 
     <artifactId>arquillian-warp-impl</artifactId>
+    <name>Arquillian Warp Extension: Impl</name>
 
     <dependencies>
 
@@ -18,18 +20,20 @@
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-warp-spi</artifactId>
             <version>${project.version}</version>
-        </dependency><dependency>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-warp-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+
         <!-- Servlet API -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>provided</scope>
         </dependency>
-        
+
         <!-- Arquillian Core -->
         <dependency>
             <groupId>org.jboss.arquillian.core</groupId>
@@ -49,13 +53,13 @@
             <artifactId>arquillian-container-test-impl-base</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- Little Proxy -->
         <dependency>
             <groupId>org.littleshoot</groupId>
             <artifactId>littleproxy</artifactId>
         </dependency>
-        
+
         <!-- TESTS -->
         <dependency>
             <groupId>junit</groupId>
@@ -76,14 +80,14 @@
             <groupId>org.jboss.arquillian.core</groupId>
             <artifactId>arquillian-core-impl-base</artifactId>
             <classifier>tests</classifier>
-            <version>${version.arquillian.core}</version>
+            <version>${version.arquillian_core}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-impl-base</artifactId>
             <classifier>tests</classifier>
-            <version>${version.arquillian.core}</version>
+            <version>${version.arquillian_core}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,22 +24,24 @@
 
     <scm>
         <connection>scm:git:git://git@github.com:arquillian/arquillian-extension-warp.git</connection>
-        <developerConnection>scm:git:ssh://github.com/arquillian/arquillian-extension--warp.git</developerConnection>
+        <developerConnection>scm:git:ssh://github.com/arquillian/arquillian-extension-warp.git</developerConnection>
         <url>git://github.com/arquillian/arquillian-extension-warp.git</url>
     </scm>
 
     <properties>
         <!-- Arquillian -->
-        <version.servlet-api>3.0.1</version.servlet-api>
-        <version.arquillian.core>1.0.0.Final</version.arquillian.core>
-        <version.arquillian.drone>1.0.0.Final</version.arquillian.drone>
-        
+        <version.servlet_api>3.0.1</version.servlet_api>
+        <version.arquillian_core>1.0.0.Final</version.arquillian_core>
+        <version.arquillian_drone>1.0.0.Final</version.arquillian_drone>
+
         <version.littleproxy>0.4</version.littleproxy>
-        
+
         <!-- Tests -->
         <version.junit>4.10</version.junit>
         <version.mockito>1.9.0</version.mockito>
-        <version.shrinkwrap-resolver>2.0.0-alpha-1</version.shrinkwrap-resolver>
+        <version.shrinkwrap_resolver>2.0.0-alpha-1</version.shrinkwrap_resolver>
+        <version.jboss_spec>3.0.0.Final</version.jboss_spec>
+        <version.org.jboss.jbossas>7.1.1.Final</version.org.jboss.jbossas>
 
         <!-- override from parent -->
         <maven.compiler.argument.target>1.5</maven.compiler.argument.target>
@@ -52,7 +54,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>${version.arquillian.core}</version>
+                <version>${version.arquillian_core}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -61,32 +63,35 @@
             <dependency>
                 <groupId>org.jboss.arquillian.extension</groupId>
                 <artifactId>arquillian-drone-bom</artifactId>
-                <version>${version.arquillian.drone}</version>
+                <version>${version.arquillian_drone}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
             <!-- Version Management -->
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${version.servlet-api}</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-api</artifactId>
-                <version>${version.shrinkwrap-resolver}</version>
+                <version>${version.shrinkwrap_resolver}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-                <version>${version.shrinkwrap-resolver}</version>
+                <version>${version.shrinkwrap_resolver}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-                <version>${version.shrinkwrap-resolver}</version>
+                <version>${version.shrinkwrap_resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-6.0</artifactId>
+                <version>${version.jboss_spec}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -150,7 +155,7 @@
         <module>spi</module>
         <module>impl</module>
         <module>ftest</module>
-        
+
         <!-- extensions -->
         <module>extension/phaser</module>
         <module>extension/phaser-ftest</module>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -3,13 +3,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>arquillian-warp-parent</artifactId>
         <groupId>org.jboss.arquillian.extension</groupId>
+        <artifactId>arquillian-warp-parent</artifactId>
         <version>1.0.0.Alpha1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>arquillian-warp-spi</artifactId>
+    <name>Arquillian Warp Extension: SPI</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
- Correct Dependency Scopes
- Move version to properties
- Move version properties to parent
- Add Names to Artifacts
- Fix unused import
- Fix PhaserExtension to be able to package with out JSF libs on client classpath
