### PR TITLE
ARQ-1027: use web-fragment.xml instead of @WebServlet for CommandEventBusServlet.

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/deployment/DeploymentEnricher.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/deployment/DeploymentEnricher.java
@@ -130,6 +130,9 @@ public class DeploymentEnricher implements ApplicationArchiveProcessor, Auxiliar
             archive.addClass(WarpRemoteExtension.class);
             archive.addAsServiceProvider(RemoteLoadableExtension.class.getName(), WarpRemoteExtension.class.getName(),"!org.jboss.arquillian.protocol.servlet.runner.ServletRemoteExtension");
             archive.addAsServiceProvider(LifecycleManagerStore.class, LifecycleManagerStoreImpl.class);
+            archive.addAsManifestResource(
+                    "org/jboss/arquillian/warp/impl/server/command/web-fragment.xml",
+                    "web-fragment.xml");
 
             return archive;
         } else {

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/server/command/CommandEventBusServlet.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/server/command/CommandEventBusServlet.java
@@ -34,7 +34,6 @@ import org.jboss.arquillian.container.test.spi.command.Command;
  * @author atzoum
  *
  */
-@WebServlet(name = CommandEventBusServlet.WARP_EVENT_BUS_SERVLET_NAME, urlPatterns = { CommandEventBusServlet.WARP_EVENT_BUS_SERVLET_MAPPING })
 public class CommandEventBusServlet extends HttpServlet {
 
     private static final long serialVersionUID = -6992268537681002870L;

--- a/impl/src/main/resources/org/jboss/arquillian/warp/impl/server/command/web-fragment.xml
+++ b/impl/src/main/resources/org/jboss/arquillian/warp/impl/server/command/web-fragment.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright 2012, Red Hat Middleware LLC, and individual contributors
+    by the @authors tag. See the copyright.txt in the distribution for a
+    full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<web-fragment version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+   http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd">
+
+	<servlet>
+		<servlet-name>CommandEventBus</servlet-name>
+		<servlet-class>org.jboss.arquillian.warp.impl.server.command.CommandEventBusServlet</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>CommandEventBus</servlet-name>
+		<url-pattern>/CommandEventBus</url-pattern>
+	</servlet-mapping>
+</web-fragment>

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/deployment/TestDeploymentEnricherClassPath.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/deployment/TestDeploymentEnricherClassPath.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.arquillian.warp.impl.client.deployment;
 
+import java.io.File;
+
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.spi.LoadableExtension;
@@ -51,7 +53,7 @@ public class TestDeploymentEnricherClassPath {
 
         JavaArchive shrinkWrapSpi = ShrinkWrapUtils.getJavaArchiveFromClass(MemoryMapArchive.class);
         JavaArchive shrinkWrapApi = ShrinkWrapUtils.getJavaArchiveFromClass(JavaArchive.class);
-        JavaArchive shrinkWrapImpl = ShrinkWrapUtils.getJavaArchiveFromClass(ServiceExtensionLoader.class);
+        JavaArchive shrinkWrapImpl = ShrinkWrapUtils.getJavaArchiveFromClass(ServiceExtensionLoader.class).addAsResource(new File("src/main/resources/org/jboss/arquillian/warp/impl/server/command/web-fragment.xml"),"org/jboss/arquillian/warp/impl/server/command/web-fragment.xml");
 
         JavaArchive base = ShrinkWrap.create(JavaArchive.class).addClasses(DeploymentEnricher.class, WarpTest.class,
                 Inspection.class, BeforeServlet.class, AfterServlet.class, WarpRemoteExtension.class);


### PR DESCRIPTION
`@WebServlet` annotation doesn't get picked up in some deployment scenarios.
See comments [here](https://github.com/arquillian/arquillian-extension-warp/pull/9#issuecomment-13783932)
