### PR TITLE
[ARQ-1320] Warp - The NonWrittingResponse does not override the flushBuf...

### DIFF
--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/server/enrichment/TestNonWritingResponse.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/server/enrichment/TestNonWritingResponse.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 
 public class TestNonWritingResponse {
 
+    private static final int SERVICE_UNAVAILABLE = 503;
+
     private ByteArrayServletOutputStream output;
     private HttpServletResponse response;
     private NonWritingResponse nonWritingResponse;
@@ -125,6 +127,53 @@ public class TestNonWritingResponse {
 
         // then
         assertEquals("ba", output.toString());
+    }
+
+    /**
+     * Tests the {@link NonWritingResponse#flushBuffer()} method.
+     *
+     * @throws IOException if any error occurs
+     */
+    @Test
+    public void test_flushing_buffer() throws IOException {
+        // when
+        nonWritingResponse.flushBuffer();
+
+        // then
+        assertTrue("The response hasn't been committed.", nonWritingResponse.isCommitted());
+        assertFalse("The wrapped response commit hasn't been correctly handled.", response.isCommitted());
+    }
+
+    /**
+     * Tests the {@link NonWritingResponse#sendError(int)} method.
+     *
+     * @throws IOException if any error occurs
+     */
+    @Test
+    public void test_send_error() throws IOException {
+        // when
+        nonWritingResponse.sendError(SERVICE_UNAVAILABLE);
+
+        // then
+        assertTrue("The response hasn't been committed.", nonWritingResponse.isCommitted());
+        assertFalse("The wrapped response commit hasn't been correctly handled.", response.isCommitted());
+        assertEquals("The response has invalid status.", SERVICE_UNAVAILABLE, nonWritingResponse.getStatus());
+    }
+
+    /**
+     * Tests the {@link NonWritingResponse#sendError(int, String)} method.
+     *
+     * @throws IOException if any error occurs
+     */
+    @Test
+    public void test_send_error_with_message() throws IOException {
+        // when
+        nonWritingResponse.sendError(SERVICE_UNAVAILABLE, "The error message");
+
+        // then
+        assertTrue("The response hasn't been committed.", nonWritingResponse.isCommitted());
+        assertFalse("The wrapped response commit hasn't been correctly handled.", response.isCommitted());
+        assertEquals("The response has invalid status.", SERVICE_UNAVAILABLE, nonWritingResponse.getStatus());
     }
 
     private byte[] bytes(String string) {


### PR DESCRIPTION
[ARQ-1320] Warp - The NonWrittingResponse does not override the flushBuffer() method allowing for committing the response.
