### PR TITLE
ARQ-1365: CommandEventBus support redirects

### DIFF
--- a/ftest/src/main/webapp/WEB-INF/web-redirect.xml
+++ b/ftest/src/main/webapp/WEB-INF/web-redirect.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat Middleware LLC, and individual contributors
+    by the @authors tag. See the copyright.txt in the distribution for a
+    full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+  
+  <filter>
+    <filter-name>RedirectFilter</filter-name>
+    <filter-class>org.jboss.arquillian.warp.ftest.eventbus.RedirectFilter</filter-class>
+  </filter>
+  <filter-mapping>
+  	<filter-name>RedirectFilter</filter-name>
+  	<url-pattern>/*</url-pattern>
+  </filter-mapping>
+  <absolute-ordering>
+  	<others/>
+  </absolute-ordering>
+</web-app>

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/eventbus/RedirectFilter.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/eventbus/RedirectFilter.java
@@ -1,0 +1,74 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.warp.ftest.eventbus;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.warp.impl.server.command.CommandEventBusService;
+import org.jboss.arquillian.warp.impl.server.command.OperationMode;
+
+/**
+ *
+ * @author Aris Tzoumas
+ *
+ */
+public class RedirectFilter implements Filter {
+    private boolean redirect = true;
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException, ServletException {
+
+        if (req instanceof HttpServletRequest && resp instanceof HttpServletResponse) {
+            HttpServletRequest request = (HttpServletRequest) req;
+            HttpServletResponse response = (HttpServletResponse) resp;
+
+            String servletPath = request.getServletPath();
+            String operationMode = request.getParameter("operationMode");
+
+            /*
+             *  only redirect the first PUT operation - @BeforeSuiteRemoteEvent
+             *  If this redirect fails the whole test will fail.
+             */
+            if (servletPath != null && servletPath.equals(CommandEventBusService.COMMAND_EVENT_BUS_MAPPING) && OperationMode.PUT.name().equals(operationMode) && redirect) {
+                redirect = false;
+                response.sendRedirect(request.getRequestURL().toString()+"?"+request.getQueryString());
+            } else {
+                chain.doFilter(req, resp);
+            }
+        } else {
+            chain.doFilter(req, resp);
+        }
+
+    }
+
+    @Override
+    public void init(FilterConfig arg0) throws ServletException {
+    }
+
+}

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/eventbus/TestEventBusHttpRedirect.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/eventbus/TestEventBusHttpRedirect.java
@@ -1,0 +1,68 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.warp.ftest.eventbus;
+
+import java.io.File;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.warp.WarpTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ *
+ * @author Aris Tzoumas
+ *
+ */
+@RunWith(Arquillian.class)
+@WarpTest
+@RunAsClient
+public class TestEventBusHttpRedirect {
+
+    @Drone
+    private WebDriver browser;
+
+    @ArquillianResource
+    private URL contextPath;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "test.war")
+                .addClass(RedirectFilter.class)
+                .addAsWebResource(new File("src/main/webapp/index.html"))
+                .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web-redirect.xml"), "web.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+
+    }
+
+    @Test
+    public void testRedirectWorks() {
+        // if test runs this means that redirect is supported in CommandEventBus
+        assertTrue(true);
+    }
+
+}

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/eventbus/CommandEventBus.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/eventbus/CommandEventBus.java
@@ -221,6 +221,19 @@ public class CommandEventBus {
         httpConnection.setUseCaches(false);
         httpConnection.setDefaultUseCaches(false);
         httpConnection.setDoInput(true);
+
+        /*
+         * With followRedirects enabled, simple URL redirects work as expected.
+         * But with port redirects (http->https) followRedirects doesn't work and
+         * a HTTP 302 code is returned instead (ARQ-1365).
+         *
+         * In order to handle all redirects in one place, followRedirects is
+         * set to false and all HTTP 302 response codes are treated accordingly
+         * within the execute method.
+         *
+         */
+        httpConnection.setInstanceFollowRedirects(false);
+
         try {
 
             if (requestObject != null) {


### PR DESCRIPTION
I did some tests and it is working, but I cannot prepare a ftest because it needs a different standalone.xml configuration and an additional test web.xml file.

However, I believe that it is out of testing scope to support https requests. Setting up certificates, keystores etc. for testing is not a trivial task.
