### PR TITLE
ARQ-1656 Add Contextual execution to HttpFilter methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <properties>
         <!-- Arquillian -->
         <version.servlet_api>3.0.1</version.servlet_api>
-        <version.arquillian_core>1.1.1.Final</version.arquillian_core>
+        <version.arquillian_core>1.1.3.Final</version.arquillian_core>
         <version.arquillian_drone>1.2.0.Final</version.arquillian_drone>
         <version.arquillian_jacoco>1.0.0.Alpha5</version.arquillian_jacoco>
 


### PR DESCRIPTION
Fixes NullPointerException in Enricher on client side
due to missing active Contexts when running on
Arquillian Core 1.1.3.Final.

Test Suite require Drone upstream to run due to similar issue:
https://github.com/arquillian/arquillian-extension-drone/commit/38c31b9c26246d1fb37e043e4fbc3c41d724549a
