### PR TITLE
ARQ-2013 Update Arquillian, Drone, Resolver, JaCoCo and JUnit

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -109,7 +109,6 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-depchain</artifactId>
-            <version>2.0.0-alpha-2</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,19 +55,19 @@
     <properties>
         <!-- Arquillian -->
         <version.servlet_api>3.0.1</version.servlet_api>
-        <version.arquillian_core>1.1.3.Final</version.arquillian_core>
-        <version.arquillian_drone>1.2.4.Final</version.arquillian_drone>
-        <version.arquillian_jacoco>1.0.0.Alpha5</version.arquillian_jacoco>
+        <version.arquillian_core>1.1.11.Final</version.arquillian_core>
+        <version.arquillian_drone>2.0.0.Beta1</version.arquillian_drone>
+        <version.arquillian_jacoco>1.0.0.Alpha8</version.arquillian_jacoco>
 
         <version.littleproxy>1.0.0-beta5</version.littleproxy>
         <version.javassist>3.12.1.GA</version.javassist>
 
         <!-- Tests -->
-        <version.junit>4.10</version.junit>
+        <version.junit>4.12</version.junit>
         <version.hamcrest>1.1</version.hamcrest>
         <version.mockito>1.9.0</version.mockito>
-        <version.jacoco>0.6.0.201210061924</version.jacoco>
-        <version.shrinkwrap_resolver>2.0.0</version.shrinkwrap_resolver>
+        <version.jacoco>0.7.4.201502262128</version.jacoco>
+        <version.shrinkwrap_resolver>2.2.2</version.shrinkwrap_resolver>
         <version.jboss_spec>3.0.0.Final</version.jboss_spec>
 
         <!-- Container Versions -->


### PR DESCRIPTION
Arquillian-core to 1.1.11.Final
Drone to 2.0.0.Beta1
Resolver to 2.2.2
Arquillian JaCoCo to 1.0.0.Alpha8
JaCoCo to 0.7.4.201502262128 to use the same implementation as Arquillian does
JUnit to 4.12