### PR TITLE
Fix checkstyle errors after update of jboss-parent to 35

### DIFF
--- a/build/resources/src/main/resources/code-style/checkstyle.xml
+++ b/build/resources/src/main/resources/code-style/checkstyle.xml
@@ -4,6 +4,8 @@
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
+  <property name="cacheFile" value="${checkstyle.cache.file}"/>
+
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
   </module>
@@ -15,8 +17,6 @@
   </module>
 
   <module name="TreeWalker">
-
-    <property name="cacheFile" value="${checkstyle.cache.file}"/>
 
     <!-- Checks for imports                              -->
     <module name="AvoidStarImport"/>

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/server/enrichment/ByteArrayServletOutputStream.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/server/enrichment/ByteArrayServletOutputStream.java
@@ -31,7 +31,7 @@ public class ByteArrayServletOutputStream extends ServletOutputStream {
         baos.write(b);
     }
 
-    private byte toByteArray()[] {
+    private byte[] toByteArray() {
         return baos.toByteArray();
     }
 


### PR DESCRIPTION
As a result of updating to jboss-parent 35, there was an error on build:

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check (checkstyle-report) on project arquillian-warp-build-resources: Failed during checkstyle configuration: cannot initialize module TreeWalker - Property 'cacheFile' does not exist, please check the documentation`

Reason/fix:  see [https://github.com/checkstyle/checkstyle/issues/2883](https://github.com/checkstyle/checkstyle/issues/2883)
The property "cacheFile" was removed on "TreeWalker", instead it should be placed on "Checker".

See also the WildFly checkstyle config at [https://github.com/wildfly/wildfly-checkstyle-config/blob/master/src/main/resources/wildfly-checkstyle/checkstyle.xml](https://github.com/wildfly/wildfly-checkstyle-config/blob/master/src/main/resources/wildfly-checkstyle/checkstyle.xml)


After fixing this, there was an error:

```
[INFO] There is 1 error reported by Checkstyle 8.19 with code-style/checkstyle.xml ruleset.
[ERROR] src\test\java\org\jboss\arquillian\warp\impl\server\enrichment\ByteArrayServletOutputStream.java:[34,31] (misc) ArrayTypeStyle: Array brackets at illegal position.
```


This pull requests fixes both issues.