### PR TITLE
Updated shrinkwrap-resolver to 3.1.4 to fix download of wildfly-dist from http url

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -14,7 +14,6 @@
 
   <properties>
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
-    <version.shrinkwrap.resolver>3.1.4</version.shrinkwrap.resolver>
     <version.shrinkwrap.descriptors>2.0.0</version.shrinkwrap.descriptors>
     <version.arquillian.glassfish40>1.0.2</version.arquillian.glassfish40>
 

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
-    <version.shrinkwrap.resolver>2.0.0-beta-3</version.shrinkwrap.resolver>
+    <version.shrinkwrap.resolver>3.1.4</version.shrinkwrap.resolver>
     <version.shrinkwrap.descriptors>2.0.0</version.shrinkwrap.descriptors>
     <version.arquillian.glassfish40>1.0.2</version.arquillian.glassfish40>
 
@@ -40,8 +40,27 @@
     <arquillian.launch.glassfish40>false</arquillian.launch.glassfish40>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.resolver</groupId>
+      <artifactId>shrinkwrap-resolver-depchain</artifactId>
+      <version>${version.shrinkwrap.resolver}</version>
+      <scope>test</scope>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+
   <dependencyManagement>
     <dependencies>
+      <!--Should not be necessary (https://github.com/shrinkwrap/resolver), but is required here. 
+          Maybe because of a conflict with an older Arquillian version? -->
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-bom</artifactId>
+        <version>${version.shrinkwrap.resolver}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
         <artifactId>arquillian-warp-build</artifactId>
@@ -58,13 +77,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-bom</artifactId>
-        <version>${version.shrinkwrap.resolver}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.jboss.shrinkwrap.descriptors</groupId>
         <artifactId>shrinkwrap-descriptors-bom</artifactId>
         <version>${version.shrinkwrap.descriptors}</version>
@@ -72,31 +84,10 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-depchain</artifactId>
-        <type>pom</type>
-        <version>${version.shrinkwrap.resolver}</version>
-      </dependency>
-      <dependency>
         <groupId>org.jboss.shrinkwrap.descriptors</groupId>
         <artifactId>shrinkwrap-descriptors-depchain</artifactId>
         <type>pom</type>
         <version>${version.shrinkwrap.descriptors}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-api</artifactId>
-        <version>${version.shrinkwrap.resolver}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-        <version>${version.shrinkwrap.resolver}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-        <version>${version.shrinkwrap.resolver}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
         <artifactId>shrinkwrap-resolver-api</artifactId>
-        <version>${version.shrinkwrap_resolver}</version>
+        <version>${version.shrinkwrap.resolver}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
         <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-        <version>${version.shrinkwrap_resolver}</version>
+        <version>${version.shrinkwrap.resolver}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
         <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-        <version>${version.shrinkwrap_resolver}</version>
+        <version>${version.shrinkwrap.resolver}</version>
       </dependency>
 
       <!-- LittleProxy -->

--- a/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInstaller.java
+++ b/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInstaller.java
@@ -88,6 +88,10 @@ public class ContainerInstaller {
         configuration.get().setContainerInstalledFromDistribution(true);
     }
 
+    /*
+     * Will only be called if the build\ftest-base\pom.xml property "arquillian.container.configuration" contains the id of a maven artifact.
+     * Probably only valid for managed containers, but not remote containers.
+     */
     public void unpackContainerConfigurationFiles(@Observes ConfigureContainer event) {
         Validate.notNull(configuration, "fundamental test configuration is not setup");
 
@@ -100,7 +104,7 @@ public class ContainerInstaller {
         Validate.notNull(configuration.get().getContainerHome(), "container home must be set");
         File containerHome = new File(configuration.get().getContainerHome());
 
-        InputStream artifactStream = Maven.resolver().resolve(configurationFiles).withClassPathResolution(false)
+        InputStream artifactStream = Maven.configureResolver().withClassPathResolution(false).resolve(configurationFiles)
             .withoutTransitivity().asSingleInputStream();
         unzip(artifactStream, containerHome, true);
 
@@ -118,6 +122,9 @@ public class ContainerInstaller {
 
             if (containerHome.exists()) {
                 FileUtils.deleteQuietly(containerHome);
+                if (FileUtils.deleteQuietly(containerHome) == false) {
+                    log.severe (String.format("could not delete container from '%s'", containerHome.getAbsolutePath()));
+                }
             }
         }
     }

--- a/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInstaller.java
+++ b/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInstaller.java
@@ -89,8 +89,8 @@ public class ContainerInstaller {
     }
 
     /*
-     * Will only be called if the build\ftest-base\pom.xml property "arquillian.container.configuration" contains the id of a maven artifact.
-     * Probably only valid for managed containers, but not remote containers.
+     * Will unpack the maven artifact declared in the build\ftest-base\pom.xml property "arquillian.container.configuration".
+     * Probably only valid for managed containers, but not for remote containers.
      */
     public void unpackContainerConfigurationFiles(@Observes ConfigureContainer event) {
         Validate.notNull(configuration, "fundamental test configuration is not setup");
@@ -121,7 +121,6 @@ public class ContainerInstaller {
             log.info(String.format("The container will be uninstalled from '%s'", containerHome.getAbsolutePath()));
 
             if (containerHome.exists()) {
-                FileUtils.deleteQuietly(containerHome);
                 if (FileUtils.deleteQuietly(containerHome) == false) {
                     log.severe (String.format("could not delete container from '%s'", containerHome.getAbsolutePath()));
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <version.hamcrest>1.3</version.hamcrest>
     <version.mockito>1.10.19</version.mockito>
     <version.jacoco>0.8.3</version.jacoco>
-	<version.shrinkwrap_resolver>3.1.4</version.shrinkwrap_resolver>
+    <version.shrinkwrap_resolver>3.1.4</version.shrinkwrap_resolver>
     <version.jboss_spec>3.0.3.Final</version.jboss_spec>
 
     <!-- Container Versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <version.hamcrest>1.3</version.hamcrest>
     <version.mockito>1.10.19</version.mockito>
     <version.jacoco>0.8.3</version.jacoco>
-    <version.shrinkwrap_resolver>2.2.6</version.shrinkwrap_resolver>
+	<version.shrinkwrap_resolver>3.1.4</version.shrinkwrap_resolver>
     <version.jboss_spec>3.0.3.Final</version.jboss_spec>
 
     <!-- Container Versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <version.hamcrest>1.3</version.hamcrest>
     <version.mockito>1.10.19</version.mockito>
     <version.jacoco>0.8.3</version.jacoco>
-    <version.shrinkwrap_resolver>3.1.4</version.shrinkwrap_resolver>
+    <version.shrinkwrap.resolver>3.1.4</version.shrinkwrap.resolver>
     <version.jboss_spec>3.0.3.Final</version.jboss_spec>
 
     <!-- Container Versions -->


### PR DESCRIPTION
Previous version 2.0.0-beta-3 caused on error on downloading wildfly-dist from maven, as it used a http url. Recent shrinkwrap-resolver uses a https url.

This pull request replaces https://github.com/arquillian/arquillian-extension-warp/pull/72 by dependabot.