### PR TITLE
Fixes deprecation warnings and generics warnings, removed unused imports

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/warp/client/filter/matcher/MatcherBuilder.java
+++ b/api/src/main/java/org/jboss/arquillian/warp/client/filter/matcher/MatcherBuilder.java
@@ -19,7 +19,7 @@ package org.jboss.arquillian.warp.client.filter.matcher;
 /**
  * A base interface for all matcher builders.
  */
-public interface MatcherBuilder<T extends MatcherBuilder> {
+public interface MatcherBuilder<T extends MatcherBuilder<T>> {
 
     /**
      * Creates negated matcher.

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/commandBus/TestEventBusHttpRedirect.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/commandBus/TestEventBusHttpRedirect.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Aris Tzoumas

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/inspection/inheritance/TestDifferentClassTypes.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/inspection/inheritance/TestDifferentClassTypes.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.warp.ftest.TestingServlet;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/inspection/qualifiers/TestEventProducer.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/inspection/qualifiers/TestEventProducer.java
@@ -20,7 +20,6 @@ import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
-import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.warp.spi.LifecycleManager;
 import org.jboss.arquillian.warp.spi.WarpLifecycleEvent;
 import org.jboss.arquillian.warp.spi.servlet.event.BeforeServlet;

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultHttpHeaderMatcherBuilder.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultHttpHeaderMatcherBuilder.java
@@ -119,7 +119,7 @@ public class DefaultHttpHeaderMatcherBuilder extends AbstractMatcherFilterBuilde
      * {@inheritDoc}
      */
     @Override
-    public HttpHeaderMatcherBuilder not() {
+    public HttpHeaderMatcherBuilder<HttpFilterBuilder> not() {
 
         return new DefaultHttpHeaderMatcherBuilder(new NotHttpFilterChainBuilder(getFilterChainBuilder()));
     }

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultHttpParameterMatcherBuilder.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultHttpParameterMatcherBuilder.java
@@ -112,7 +112,7 @@ public class DefaultHttpParameterMatcherBuilder extends AbstractMatcherFilterBui
      * {@inheritDoc}
      */
     @Override
-    public HttpParameterMatcherBuilder not() {
+    public HttpParameterMatcherBuilder<HttpFilterBuilder> not() {
 
         return new DefaultHttpParameterMatcherBuilder(new NotHttpFilterChainBuilder(getFilterChainBuilder()));
     }

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultMethodMatcherBuilder.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultMethodMatcherBuilder.java
@@ -65,7 +65,7 @@ public class DefaultMethodMatcherBuilder extends AbstractMatcherFilterBuilder
      * {@inheritDoc}
      */
     @Override
-    public MethodMatcherBuilder not() {
+    public MethodMatcherBuilder<HttpFilterBuilder> not() {
 
         return new DefaultMethodMatcherBuilder(new NotHttpFilterChainBuilder(getFilterChainBuilder()));
     }

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultUriMatcherBuilder.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultUriMatcherBuilder.java
@@ -174,7 +174,7 @@ public class DefaultUriMatcherBuilder extends AbstractMatcherFilterBuilder
      * {@inheritDoc}
      */
     @Override
-    public UriMatcherBuilder not() {
+    public UriMatcherBuilder<HttpFilterBuilder> not() {
 
         return new DefaultUriMatcherBuilder(new NotHttpFilterChainBuilder(getFilterChainBuilder()));
     }

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/transformation/MigratedInspection.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/transformation/MigratedInspection.java
@@ -19,7 +19,6 @@ package org.jboss.arquillian.warp.impl.client.transformation;
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 
 import javassist.ClassPool;
 import javassist.CtClass;

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/server/execution/WarpRequestProcessor.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/server/execution/WarpRequestProcessor.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.test.spi.TestResult;
-import org.jboss.arquillian.test.spi.TestResult.Status;
 import org.jboss.arquillian.warp.impl.server.event.EnrichHttpResponse;
 import org.jboss.arquillian.warp.impl.server.event.RequestProcessingFinished;
 import org.jboss.arquillian.warp.impl.server.event.RequestProcessingStarted;
@@ -62,7 +61,7 @@ public class WarpRequestProcessor {
         try {
             executeWarp.fire(new ExecuteWarp());
         } catch (Throwable e) {
-            testResult.fire(new TestResult(Status.FAILED, e));
+            testResult.fire(TestResult.failed(e));
         }
 
         if (responsePayload.getTestResult() != null) {
@@ -73,7 +72,7 @@ public class WarpRequestProcessor {
                 }
             }
         } else {
-            responsePayload.setTestResult(new TestResult(Status.PASSED));
+            responsePayload.setTestResult(TestResult.passed());
         }
 
         try {

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/server/test/TestResultObserver.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/server/test/TestResultObserver.java
@@ -36,7 +36,7 @@ public class TestResultObserver {
         throwable.printStackTrace();
 
         if (responsePayload() != null) {
-            storeFirstFailure(new TestResult(Status.FAILED, throwable));
+            storeFirstFailure(TestResult.failed(throwable));
         }
 
         // throwable must be rethrown, because Arquillian Core checks whether throwable was observed

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestDefaultWarpExecutor.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestDefaultWarpExecutor.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.spi.Manager;
 import org.jboss.arquillian.test.spi.TestResult;
-import org.jboss.arquillian.test.spi.TestResult.Status;
 import org.jboss.arquillian.warp.Activity;
 import org.jboss.arquillian.warp.impl.client.execution.DefaultWarpRequestSpecifier.ActivityException;
 import org.jboss.arquillian.warp.impl.client.scope.WarpExecutionContext;
@@ -74,7 +73,7 @@ public class TestDefaultWarpExecutor extends AbstractWarpClientTestTestBase {
     @Test
     public void when_client_activity_fails_and_request_result_is_failure_then_server_failure_should_be_reported() {
         // given
-        TestResult result = new TestResult(Status.FAILED, new RuntimeException("server"));
+        TestResult result = TestResult.failed(new RuntimeException("server"));
         when(warpContext.getFirstNonSuccessfulResult()).thenReturn(result);
 
         doThrow(new RuntimeException("client")).when(activity).perform();
@@ -94,7 +93,7 @@ public class TestDefaultWarpExecutor extends AbstractWarpClientTestTestBase {
     @Test
     public void when_server_activity_fails_without_client_failure_then_server_failure_should_be_reported() {
         // given
-        TestResult result = new TestResult(Status.FAILED, new RuntimeException("server"));
+        TestResult result = TestResult.failed(new RuntimeException("server"));
         when(warpContext.getFirstNonSuccessfulResult()).thenReturn(result);
 
         // when

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/server/execution/TestTestResultObserver.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/server/execution/TestTestResultObserver.java
@@ -76,7 +76,7 @@ public class TestTestResultObserver extends AbstractWarpServerTestTestBase {
     public void when_test_result_with_failure_is_observed_then_it_is_propagated_to_response_payload() {
 
         // having
-        TestResult testResult = new TestResult(Status.FAILED);
+        TestResult testResult = TestResult.failed(null);
 
         // when
         fire(testResult);
@@ -88,7 +88,7 @@ public class TestTestResultObserver extends AbstractWarpServerTestTestBase {
     @Test
     public void when_test_result_passed_is_observed_then_it_is_ignored() {
         // having
-        TestResult testResult = new TestResult(Status.PASSED);
+        TestResult testResult = TestResult.passed();
 
         // when
         fire(testResult);
@@ -100,8 +100,8 @@ public class TestTestResultObserver extends AbstractWarpServerTestTestBase {
     @Test
     public void when_two_failed_test_results_are_observed_then_first_one_is_saved_in_response_payload() {
         // having
-        TestResult testResult1 = new TestResult(Status.FAILED);
-        TestResult testResult2 = new TestResult(Status.FAILED);
+        TestResult testResult1 = TestResult.failed(null);
+        TestResult testResult2 = TestResult.failed(null);
 
         // when
         fire(testResult1);
@@ -116,7 +116,7 @@ public class TestTestResultObserver extends AbstractWarpServerTestTestBase {
 
         // having
         TestResultSetup setup = new TestResultSetup();
-        setup.testResult = new TestResult(Status.FAILED);
+        setup.testResult = TestResult.failed(null);
 
         // when
         fire(setup);

--- a/spi/src/main/java/org/jboss/arquillian/warp/spi/servlet/event/AfterServlet.java
+++ b/spi/src/main/java/org/jboss/arquillian/warp/spi/servlet/event/AfterServlet.java
@@ -17,7 +17,6 @@
 package org.jboss.arquillian.warp.spi.servlet.event;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 

--- a/spi/src/main/java/org/jboss/arquillian/warp/spi/servlet/event/BeforeServlet.java
+++ b/spi/src/main/java/org/jboss/arquillian/warp/spi/servlet/event/BeforeServlet.java
@@ -17,7 +17,6 @@
 package org.jboss.arquillian.warp.spi.servlet.event;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 


### PR DESCRIPTION
Code cleanup:
-fixed all deprecation warnings
-fixed some other warnings (unused imports, "References to generic type ... should be parametrized")

I will send the rest of the changed of pull request #85 (jboss-parent version, Java 1.8, "Missing artifact sun.jdk:jconsole:jar:jdk") when this request was merged. Would this mean three pull requests, or can I combine any of the changes?