### PR TITLE
Updated to Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,10 +78,6 @@
     <version.tomcat7>7.0.26</version.tomcat7>
     <version.wildfly>8.2.1.Final</version.wildfly>
 
-    <!-- override from parent -->
-    <maven.compiler.argument.target>1.8</maven.compiler.argument.target>
-    <maven.compiler.argument.source>1.8</maven.compiler.argument.source>
-
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
     <version.wildfly>8.2.1.Final</version.wildfly>
 
     <!-- override from parent -->
-    <maven.compiler.argument.target>1.5</maven.compiler.argument.target>
-    <maven.compiler.argument.source>1.5</maven.compiler.argument.source>
+    <maven.compiler.argument.target>1.8</maven.compiler.argument.target>
+    <maven.compiler.argument.source>1.8</maven.compiler.argument.source>
 
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>


### PR DESCRIPTION
The previous version 1.5 does not even work when using a JDK 1.5 - the extension already used Java 1.6 code.