### PR TITLE
Workaround "Missing artifact sun.jdk:jconsole:jar:jdk" error in Eclipse

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -157,6 +157,14 @@
           <artifactId>wildfly-arquillian-container-managed</artifactId>
           <version>${version.wildfly}</version>
           <scope>test</scope>
+          <!--Workaround for error "Missing artifact sun.jdk:jconsole:jar:jdk" in Eclipse.
+              Seems not to be needed for the "wildfly-remote-8-0" profile. -->
+          <exclusions>
+            <exclusion>
+              <groupId>sun.jdk</groupId>
+              <artifactId>jconsole</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
When importing the project to Eclipse, this error is reported: "Missing artifact sun.jdk:jconsole:jar:jdk"

According to [https://stackoverflow.com/questions/33236195/missing-artifact-sun-jdkjconsolejarjdk](https://stackoverflow.com/questions/33236195/missing-artifact-sun-jdkjconsolejarjdk), the workaround is to add an exclusion to this package. With this workaround, the error is gone, and "mvn clean install" still works.
This should be a temporary workaround, as newer WildFly versions don't need it.