### PR TITLE
Fixed Eclipse warning about shrinkwrap-resolver version

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -41,23 +41,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!--Should not be necessary (https://github.com/shrinkwrap/resolver), but is required here. 
-          Otherwise an error "java.lang.ClassNotFoundException: org.jboss.shrinkwrap.resolver.spi.format.PathFormatProcessor" will occur.
-          Maybe because of a conflict with an older Arquillian version? -->
-      <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-bom</artifactId>
-        <version>${version.shrinkwrap.resolver}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-depchain</artifactId>
-        <version>${version.shrinkwrap.resolver}</version>
-        <scope>test</scope>
-        <type>pom</type>
-      </dependency>
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
         <artifactId>arquillian-warp-build</artifactId>

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -39,19 +39,10 @@
     <arquillian.launch.glassfish40>false</arquillian.launch.glassfish40>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.jboss.shrinkwrap.resolver</groupId>
-      <artifactId>shrinkwrap-resolver-depchain</artifactId>
-      <version>${version.shrinkwrap.resolver}</version>
-      <scope>test</scope>
-      <type>pom</type>
-    </dependency>
-  </dependencies>
-
   <dependencyManagement>
     <dependencies>
       <!--Should not be necessary (https://github.com/shrinkwrap/resolver), but is required here. 
+          Otherwise an error "java.lang.ClassNotFoundException: org.jboss.shrinkwrap.resolver.spi.format.PathFormatProcessor" will occur.
           Maybe because of a conflict with an older Arquillian version? -->
       <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
@@ -59,6 +50,13 @@
         <version>${version.shrinkwrap.resolver}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-depchain</artifactId>
+        <version>${version.shrinkwrap.resolver}</version>
+        <scope>test</scope>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -14,6 +14,16 @@
   <dependencyManagement>
     <dependencies>
 
+      <!-- ShrinkWrap -->
+      <!--First declare the shrinkwrap-resolver bom to override version 2.2.6 pulled from elsewhere -->
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-bom</artifactId>
+        <version>${version.shrinkwrap.resolver}</version>
+        <scope>import</scope>
+        <type>pom</type>
+     </dependency>
+
       <!-- Arquillian dependencies -->
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
@@ -55,23 +65,6 @@
         <version>${version.jboss_spec}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <!-- ShrinkWrap -->
-      <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-api</artifactId>
-        <version>${version.shrinkwrap.resolver}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-        <version>${version.shrinkwrap.resolver}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-        <version>${version.shrinkwrap.resolver}</version>
       </dependency>
 
       <!-- LittleProxy -->

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -105,13 +105,6 @@
       <version>${version.arquillian_core}</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.jboss.shrinkwrap.resolver</groupId>
-      <artifactId>shrinkwrap-resolver-depchain</artifactId>
-      <type>pom</type>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
My previous update of the shrinkwrap-resolver to 3.1.4 version introduced a warning in Eclipse:

"Overriding managed version 3.1.4 for shrinkwrap-resolver-depchain"

I fixed it by moving the declaration of "org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-depchain" from a root "dependencies" element to "dependencyManagement/dependencies".

Is this reasonable ;-)? At least it works.

Simply removing the "version" element in my initial pom.xml resulted in a Eclipse error "missing version".