### PR TITLE
Fixed deprecation warnings after JUnit update

### DIFF
--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/failure/TestSerializationFailurePropagation.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/failure/TestSerializationFailurePropagation.java
@@ -17,7 +17,7 @@
 package org.jboss.arquillian.warp.ftest.failure;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.File;

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/http/TestResponseContainsProxyUrl.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/http/TestResponseContainsProxyUrl.java
@@ -17,7 +17,7 @@
 package org.jboss.arquillian.warp.ftest.http;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/integration/NonWarpTest.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/integration/NonWarpTest.java
@@ -18,7 +18,7 @@ package org.jboss.arquillian.warp.ftest.integration;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.File;

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/observer/TestHttpParameterFiltering.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/observer/TestHttpParameterFiltering.java
@@ -18,7 +18,7 @@ package org.jboss.arquillian.warp.ftest.observer;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.jboss.arquillian.warp.client.filter.http.HttpFilters.request;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.net.URL;

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/observer/TestRequestObserver.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/observer/TestRequestObserver.java
@@ -18,7 +18,7 @@ package org.jboss.arquillian.warp.ftest.observer;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.jboss.arquillian.warp.client.filter.http.HttpFilters.request;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.net.URL;

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/observer/TestRequestObserverFailureReporting.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/observer/TestRequestObserverFailureReporting.java
@@ -18,7 +18,7 @@ package org.jboss.arquillian.warp.ftest.observer;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.jboss.arquillian.warp.client.filter.http.HttpFilters.request;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.net.URL;

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/filter/http/TestMatchersToString.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/filter/http/TestMatchersToString.java
@@ -18,7 +18,7 @@ package org.jboss.arquillian.warp.impl.client.filter.http;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.jboss.arquillian.warp.client.filter.http.HttpFilters.request;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.jboss.arquillian.warp.client.execution.WarpActivityBuilder;
 import org.jboss.arquillian.warp.client.execution.WarpRuntime;


### PR DESCRIPTION
The recent JUnit update to 4.13.1 caused another bunch of deprecation warnings: "org.junit.Assert.assertThat" is deprecated and should be replaced by "org.hamcrest.MatcherAssert.assertThat".

So this commit replaces
`import static org.junit.Assert.assertThat;`

with
`import static org.hamcrest.MatcherAssert.assertThat;`