### PR TITLE
Upgrade arquillian-drone-bom from 2.0.0.Beta1 to 3.0.0-alpha.7

### DIFF
--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -83,6 +83,20 @@
       <groupId>org.jboss.arquillian.extension</groupId>
       <artifactId>arquillian-warp-build-resources</artifactId>
     </dependency>
+    
+    <!--Required after updating to Drone 3.0.0.Alpha7
+        Fixed this error at test execution:
+          
+        [ERROR] org.jboss.arquillian.warp.jsf.ftest.BasicJsfTest  Time elapsed: 0.55 s  <<< ERROR!
+        java.lang.NoClassDefFoundError: org/jboss/shrinkwrap/resolver/api/maven/Maven
+          at org.arquillian.warp.ftest.installation.ContainerInstaller.unpackContainerDistribution(ContainerInstaller.java:73)
+     -->
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.resolver</groupId>
+      <artifactId>shrinkwrap-resolver-depchain</artifactId>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/BasicJsfTest.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/BasicJsfTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.net.URL;
+import java.time.Duration;
+import java.util.function.Function;
 
 import javax.inject.Inject;
 
@@ -46,8 +48,6 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
-
-import com.google.common.base.Predicate;
 
 @RunWith(Arquillian.class)
 @WarpTest
@@ -125,9 +125,9 @@ public class BasicJsfTest {
                      }
             );
 
-        new WebDriverWait(browser, 5).until(new Predicate<WebDriver>() {
+        new WebDriverWait(browser, Duration.ofSeconds(5)).until(new Function<WebDriver, Boolean>() {
             @Override
-            public boolean apply(WebDriver browser) {
+            public Boolean apply(WebDriver browser) {
                 WebElement output = browser.findElement(By.id("helloWorldJsf:output"));
                 try {
                     return output.getText().contains("JohnX");

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestJsfLifecycle.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestJsfLifecycle.java
@@ -18,6 +18,8 @@ package org.jboss.arquillian.warp.jsf.ftest.lifecycle;
 
 import java.io.File;
 import java.net.URL;
+import java.time.Duration;
+import java.util.function.Function;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -42,8 +44,6 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
-
-import com.google.common.base.Predicate;
 
 @WarpTest
 @RunAsClient
@@ -159,9 +159,9 @@ public class TestJsfLifecycle {
                 }
             });
 
-        new WebDriverWait(browser, 5).until(new Predicate<WebDriver>() {
+        new WebDriverWait(browser, Duration.ofSeconds(5)).until(new Function<WebDriver, Boolean>() {
             @Override
-            public boolean apply(WebDriver browser) {
+            public Boolean apply(WebDriver browser) {
                 WebElement output = browser.findElement(By.id("helloWorldJsf:output"));
                 try {
                     return output.getText().contains("JohnX");

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -76,6 +76,19 @@
       <scope>test</scope>
     </dependency>
 
+    <!--Required after updating to Drone 3.0.0.Alpha7
+        Fixed this error at test execution:
+        
+        [ERROR] org.jboss.arquillian.warp.ftest.BasicWarpTest  Time elapsed: 0.505 s  <<< ERROR!
+        java.lang.NoClassDefFoundError: org/jboss/shrinkwrap/resolver/api/maven/Maven
+          at org.arquillian.warp.ftest.installation.ContainerInstaller.unpackContainerDistribution(ContainerInstaller.java:73)
+     -->
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.resolver</groupId>
+      <artifactId>shrinkwrap-resolver-depchain</artifactId>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <!-- Arquillian -->
     <version.servlet_api>3.0.1</version.servlet_api>
     <version.arquillian_core>1.6.0.Final</version.arquillian_core>
-    <version.arquillian_drone>2.0.0.Beta1</version.arquillian_drone>
+    <version.arquillian_drone>3.0.0-alpha.7</version.arquillian_drone>
     <version.arquillian_jacoco>1.0.0.Alpha10</version.arquillian_jacoco>
 
     <version.littleproxy>1.0.0-beta5</version.littleproxy>


### PR DESCRIPTION
..and fixes two compilation errors due to API changes. Also adds the dependency "shrinkwrap-resolver-depchain" to two test project poms to avoid runtime errors.

This replaces dependabot pull request #91 