### PR TITLE
Removed old WildFly/JBoss containers, updated to WildFly 26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,3 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: org.jboss.as:jboss-as-arquillian-container-managed
-    versions:
-    - "> 7.1.1.Final"
-  - dependency-name: org.jboss.as:jboss-as-arquillian-container-remote
-    versions:
-    - "> 7.1.1.Final"
-  - dependency-name: org.codehaus.mojo:animal-sniffer-maven-plugin
-    versions:
-    - "1.19"
-  - dependency-name: org.jboss.arquillian.extension:arquillian-drone-bom
-    versions:
-    - 2.1.0.Beta1

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -32,7 +32,7 @@
     <arquillian.contaner.maxTestClassesBeforeRestart>50</arquillian.contaner.maxTestClassesBeforeRestart>
 
     <!-- Container Selection -->
-    <arquillian.launch.wildfly261>true</arquillian.launch.wildfly261>
+    <arquillian.launch.wildfly>true</arquillian.launch.wildfly>
     <arquillian.launch.tomcat6>false</arquillian.launch.tomcat6>
     <arquillian.launch.tomcat7>false</arquillian.launch.tomcat7>
     <arquillian.launch.tomee16>false</arquillian.launch.tomee16>
@@ -118,16 +118,16 @@
     <!-- Containers -->
 
     <profile>
-      <id>wildfly-managed-26-1</id>
+      <id>wildfly-managed</id>
       <activation>
         <activeByDefault>true</activeByDefault>
         <property>
           <name>integration</name>
-          <value>wildfly261</value>
+          <value>wildfly</value>
         </property>
       </activation>
       <properties>
-        <arquillian.launch.wildfly261>true</arquillian.launch.wildfly261>
+        <arquillian.launch.wildfly>true</arquillian.launch.wildfly>
         <arquillian.container.home>${project.build.directory}/wildfly-${version.wildfly}</arquillian.container.home>
         <arquillian.container.distribution>org.wildfly:wildfly-dist:zip:${version.wildfly}
         </arquillian.container.distribution>
@@ -142,7 +142,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>wildfly-remote-26-1</id>
+      <id>wildfly-remote</id>
       <dependencies>
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -32,7 +32,7 @@
     <arquillian.contaner.maxTestClassesBeforeRestart>50</arquillian.contaner.maxTestClassesBeforeRestart>
 
     <!-- Container Selection -->
-    <arquillian.launch.jbossas71>false</arquillian.launch.jbossas71>
+    <arquillian.launch.wildfly261>true</arquillian.launch.wildfly261>
     <arquillian.launch.tomcat6>false</arquillian.launch.tomcat6>
     <arquillian.launch.tomcat7>false</arquillian.launch.tomcat7>
     <arquillian.launch.tomee16>false</arquillian.launch.tomee16>
@@ -99,7 +99,7 @@
                 <artifactItem>
                   <groupId>org.jboss.arquillian.extension</groupId>
                   <artifactId>arquillian-warp-build-resources</artifactId>
-                  <version>${version.richfaces}</version>
+                  <version>${project.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                 </artifactItem>
@@ -118,138 +118,36 @@
     <!-- Containers -->
 
     <profile>
-      <id>wildfly-managed-8-0</id>
+      <id>wildfly-managed-26-1</id>
       <activation>
         <activeByDefault>true</activeByDefault>
         <property>
           <name>integration</name>
-          <value>wildfly80</value>
+          <value>wildfly261</value>
         </property>
       </activation>
       <properties>
-        <arquillian.launch.jbossas71>true</arquillian.launch.jbossas71>
+        <arquillian.launch.wildfly261>true</arquillian.launch.wildfly261>
         <arquillian.container.home>${project.build.directory}/wildfly-${version.wildfly}</arquillian.container.home>
         <arquillian.container.distribution>org.wildfly:wildfly-dist:zip:${version.wildfly}
         </arquillian.container.distribution>
       </properties>
       <dependencies>
         <dependency>
-          <groupId>org.wildfly</groupId>
+          <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.wildfly}</version>
+          <version>${version.wildfly.arquillian.container}</version>
           <scope>test</scope>
-          <!--Workaround for error "Missing artifact sun.jdk:jconsole:jar:jdk" in Eclipse.
-              Seems not to be needed for the "wildfly-remote-8-0" profile. -->
-          <exclusions>
-            <exclusion>
-              <groupId>sun.jdk</groupId>
-              <artifactId>jconsole</artifactId>
-            </exclusion>
-          </exclusions>
         </dependency>
       </dependencies>
     </profile>
     <profile>
-      <id>wildfly-remote-8-0</id>
+      <id>wildfly-remote-26-1</id>
       <dependencies>
         <dependency>
-          <groupId>org.wildfly</groupId>
+          <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-remote</artifactId>
-          <version>${version.wildfly}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>jbossas-managed-7-1</id>
-      <activation>
-        <property>
-          <name>integration</name>
-          <value>jbossas71</value>
-        </property>
-      </activation>
-      <properties>
-        <jbossHome>${project.build.directory}/jboss-as-${version.jbossas71}</jbossHome>
-        <arquillian.launch.jbossas71>true</arquillian.launch.jbossas71>
-        <arquillian.container.home>${project.build.directory}/jboss-as-${version.jbossas71}</arquillian.container.home>
-        <arquillian.container.distribution>org.jboss.as:jboss-as-dist:zip:${version.jbossas71}
-        </arquillian.container.distribution>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-managed</artifactId>
-          <version>${version.jbossas71}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>jbossas-remote-7-1</id>
-      <activation>
-        <property>
-          <name>integration</name>
-          <value>jbossas71-remote</value>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-remote</artifactId>
-          <version>${version.jbossas71}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>jbosseap-managed-6-1</id>
-      <activation>
-        <property>
-          <name>integration</name>
-          <value>jbosseap61</value>
-        </property>
-      </activation>
-      <properties>
-        <version.jbosseap61>7.2.0.Alpha1-redhat-4</version.jbosseap61>
-        <arquillian.launch.jbossas71>true</arquillian.launch.jbossas71>
-        <arquillian.container.home>${project.build.directory}/jboss-eap-6.1</arquillian.container.home>
-        <arquillian.container.distribution>org.jboss.as:jboss-as-dist:zip:${version.jbosseap61}
-        </arquillian.container.distribution>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-managed</artifactId>
-          <version>7.2.0.Final</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-controller-client</artifactId>
-          <version>7.2.0.Final</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>jbosseap-remote-6-1</id>
-      <activation>
-        <property>
-          <name>integration</name>
-          <value>jbosseap61-remote</value>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-remote</artifactId>
-          <version>7.2.0.Final</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-controller-client</artifactId>
-          <version>7.2.0.Final</version>
+          <version>${version.wildfly.arquillian.container}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/build/resources/src/main/resources/arquillian.xml
+++ b/build/resources/src/main/resources/arquillian.xml
@@ -27,7 +27,7 @@
     <!--         <property name="deploymentExportPath">target/</property> -->
   </engine>
 
-  <container qualifier="jbossas71" default="${arquillian.launch.jbossas71}">
+  <container qualifier="wildfly261" default="${arquillian.launch.wildfly261}">
     <configuration>
       <property name="javaVmArguments">${arquillian.container.vmargs}</property>
       <property name="jbossHome">${arquillian.container.home}</property>

--- a/build/resources/src/main/resources/arquillian.xml
+++ b/build/resources/src/main/resources/arquillian.xml
@@ -27,7 +27,7 @@
     <!--         <property name="deploymentExportPath">target/</property> -->
   </engine>
 
-  <container qualifier="wildfly261" default="${arquillian.launch.wildfly261}">
+  <container qualifier="wildfly" default="${arquillian.launch.wildfly}">
     <configuration>
       <property name="javaVmArguments">${arquillian.container.vmargs}</property>
       <property name="jbossHome">${arquillian.container.home}</property>

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceNotFound.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceNotFound.java
@@ -51,7 +51,7 @@ public class TestJSFResourceNotFound {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "jsf-test.war")
-            .addAsWebInfResource(new StringAsset("<faces-config></faces-config>"), "faces-config.xml");
+            .addAsWebInfResource(new StringAsset("<faces-config version=\"2.0\" xmlns=\"http://java.sun.com/xml/ns/javaee\" xmlns:xi=\"http://www.w3.org/2001/XInclude\"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd\"></faces-config>"), "faces-config.xml");
     }
 
     @Test

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceNotFound.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceNotFound.java
@@ -51,7 +51,7 @@ public class TestJSFResourceNotFound {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "jsf-test.war")
-            .addAsWebInfResource(new StringAsset("<faces-config version=\"2.0\" xmlns=\"http://java.sun.com/xml/ns/javaee\" xmlns:xi=\"http://www.w3.org/2001/XInclude\"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd\"></faces-config>"), "faces-config.xml");
+            .addAsWebInfResource(new StringAsset("<faces-config version=\"2.0\" xmlns=\"http://java.sun.com/xml/ns/javaee\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd\"></faces-config>"), "faces-config.xml");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,13 @@
     <version.jboss_spec>3.0.3.Final</version.jboss_spec>
 
     <!-- Container Versions -->
-    <version.jbossas71>7.1.1.Final</version.jbossas71>
     <version.tomee16>1.7.5</version.tomee16>
     <version.glassfish40>4.0</version.glassfish40>
     <version.tomcat6>6.0.35</version.tomcat6>
     <version.tomcat7>7.0.26</version.tomcat7>
-    <version.wildfly>8.2.1.Final</version.wildfly>
+    <version.wildfly>26.1.3.Final</version.wildfly>
+	<!--Don't upgrade beyond 2.2.0.Final. 4.0.0.Alpha6 fails, and 5.0.0.Alpha6 is built with Java 11 -->
+	<version.wildfly.arquillian.container>2.2.0.Final</version.wildfly.arquillian.container>
 
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
     <version.tomcat6>6.0.35</version.tomcat6>
     <version.tomcat7>7.0.26</version.tomcat7>
     <version.wildfly>26.1.3.Final</version.wildfly>
-	<!--Don't upgrade beyond 2.2.0.Final. 4.0.0.Alpha6 fails, and 5.0.0.Alpha6 is built with Java 11 -->
-	<version.wildfly.arquillian.container>2.2.0.Final</version.wildfly.arquillian.container>
+    <!--Don't upgrade beyond 2.2.0.Final. 4.0.0.Alpha6 fails, and 5.0.0.Alpha6 is built with Java 11 -->
+    <version.wildfly.arquillian.container>2.2.0.Final</version.wildfly.arquillian.container>
 
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>


### PR DESCRIPTION
This pull request removes the old containers JBoss 7.1.1, WildFly 8.2.1 and JBoss EAP 7.2.0 and replaces them by WildFly 26.1.3.

A "clean install" run agains WildFly 8.2.1 would have failed with Maven 3.8.x because in the dependency chain a "http" repository was defined, which is blocked by default with Maven 3.8.x. It works only with the older Maven version from maven-wrapper, or with a change to the maven settings to remove the blocking rule.

Also changed:

- "extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceNotFound.java": it created an empty "faces-config.xml", which failed on WildFly 26 with a nasty StackOverflowError => solution was to define a valid version number.
- "build/ftest-base/pom.xml", maven-dependency-plugin: org.jboss.arquillian.extension:arquillian-warp-build-resources declared version "${version.richfaces}", which is an undefined variable and should probably match the current version of the extension => replaced by "${project.version}"

Is this changeset acceptable ;-)?

I think "dependabot.yml" can be cleaned up, because there are some old "ignore" dependencies that are no longer relevant with this change. What do you think?
