### PR TITLE
Upgrade jacoco from 0.8.3 to 0.8.8, arquillian-jacoco from 1.0.0.Alpha10 to 1.1.0, workaround for MethodTooLargeException

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -198,6 +198,13 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${version.jacoco}</version>
+                    <configuration>
+                        <excludes>
+                            <!--Avoid error messages "org.jacoco.agent.rt.internal_1f1cc91.asm.MethodTooLargeException: Method too large" in classes in packages listed here: -->
+                            <exclude>com/gargoylesoftware/htmlunit/css/**</exclude>
+                            <exclude>com/gargoylesoftware/css/parser/javacc/**</exclude>
+                        </excludes>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <version.servlet_api>3.0.1</version.servlet_api>
     <version.arquillian_core>1.6.0.Final</version.arquillian_core>
     <version.arquillian_drone>3.0.0-alpha.7</version.arquillian_drone>
-    <version.arquillian_jacoco>1.0.0.Alpha10</version.arquillian_jacoco>
+    <version.arquillian_jacoco>1.1.0</version.arquillian_jacoco>
 
     <version.littleproxy>1.0.0-beta5</version.littleproxy>
     <version.javassist>3.12.1.GA</version.javassist>
@@ -66,7 +66,7 @@
     <version.junit>4.13.1</version.junit>
     <version.hamcrest>1.3</version.hamcrest>
     <version.mockito>1.10.19</version.mockito>
-    <version.jacoco>0.8.3</version.jacoco>
+    <version.jacoco>0.8.8</version.jacoco>
     <version.shrinkwrap.resolver>3.1.4</version.shrinkwrap.resolver>
     <version.jboss_spec>3.0.3.Final</version.jboss_spec>
 


### PR DESCRIPTION
Update Jacoco to 0.8.8 (this replaces pull request #88).

Also, it contains a workaround for this error when executing the tests (does not make the tests fail, but looks terrifying):

```
java.lang.instrument.IllegalClassFormatException: Error while instrumenting com/gargoylesoftware/htmlunit/css/StyleAttributes$Definition with JaCoCo 0.8.8.202204050719/5dcf34a.
        at org.jacoco.agent.rt.internal_b6258fc.CoverageTransformer.transform(CoverageTransformer.java:94)
        ...
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.io.IOException: Error while instrumenting com/gargoylesoftware/htmlunit/css/StyleAttributes$Definition with JaCoCo 0.8.8.202204050719/5dcf34a.
        at org.jacoco.agent.rt.internal_b6258fc.core.instr.Instrumenter.instrumentError(Instrumenter.java:161)
        at org.jacoco.agent.rt.internal_b6258fc.core.instr.Instrumenter.instrument(Instrumenter.java:111)
        at org.jacoco.agent.rt.internal_b6258fc.CoverageTransformer.transform(CoverageTransformer.java:92)
        ... 46 more
Caused by: org.jacoco.agent.rt.internal_b6258fc.asm.MethodTooLargeException: Method too large: com/gargoylesoftware/htmlunit/css/StyleAttributes$Definition.<clinit> ()V
        at org.jacoco.agent.rt.internal_b6258fc.asm.MethodWriter.computeMethodInfoSize(MethodWriter.java:2087)
        at org.jacoco.agent.rt.internal_b6258fc.asm.ClassWriter.toByteArray(ClassWriter.java:489)
        at org.jacoco.agent.rt.internal_b6258fc.core.instr.Instrumenter.instrument(Instrumenter.java:92)
        at org.jacoco.agent.rt.internal_b6258fc.core.instr.Instrumenter.instrument(Instrumenter.java:109)
        ... 47 more
```


and

```
MethodTooLargeException: Method too large: com/gargoylesoftware/css/parser/javacc/CSS3ParserTokenManager.jjMoveNfa_0 (II)I
```

The workaround is to exclude some of the "gargoylesoftware" packages from test coverage.
