### PR TITLE
Upgrade Mockito from 1.10.19 to 4.9.0 (the latest version for Java 1.8)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,10 +34,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <!--seems to be unnessary...
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>
+    </dependency>-->
   </dependencies>
 </project>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -97,7 +97,14 @@
       <!-- Mockito -->
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-core</artifactId>
+        <version>${version.mockito}</version>
+      </dependency>
+      <!--Use "mockito-inline" by default. See "org.jboss.arquillian.warp.impl.server.test.TestLifecycleTestDriver.when_registry_contains_inspection_with_annotated_method__matching_current_lifecycle_event_then_method_is_fired"
+          for an explanation why this is necessary.-->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
         <version>${version.mockito}</version>
       </dependency>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -76,7 +76,14 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!--Use "mockito-inline" by default. See "org.jboss.arquillian.warp.impl.server.test.TestLifecycleTestDriver.when_registry_contains_inspection_with_annotated_method__matching_current_lifecycle_event_then_method_is_fired"
+          for an explanation why this is necessary.-->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestDefaultWarpExecutor.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestDefaultWarpExecutor.java
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author Lukas Fryc

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestRequestExecutionSynchronization.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestRequestExecutionSynchronization.java
@@ -48,11 +48,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -107,7 +108,7 @@ public class TestRequestExecutionSynchronization extends AbstractWarpClientTestT
         when(serviceLoader.onlyOne(WarpRequestSpecifier.class)).thenReturn(requestExecutor);
         when(serviceLoader.onlyOne(ExecutionSynchronizer.class)).thenReturn(inspectionSynchronizer);
         when(serviceLoader.onlyOne(WarpExecutor.class)).thenReturn(warpExecutor);
-        when(serviceLoader.onlyOne(WarpRuntime.class)).thenReturn(warpRuntime);
+        lenient().when(serviceLoader.onlyOne(WarpRuntime.class)).thenReturn(warpRuntime);
         when(serviceLoader.onlyOne(WarpContext.class)).thenReturn(warpContext);
 
         bind(ApplicationScoped.class, ServiceLoader.class, serviceLoader);

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/filter/http/TestHttpFilters.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/filter/http/TestHttpFilters.java
@@ -46,10 +46,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -366,9 +367,9 @@ public class TestHttpFilters extends AbstractWarpClientTestTestBase {
         WarpContext warpContext = new WarpContextImpl();
 
         when(serviceLoader.onlyOne(WarpRequestSpecifier.class)).thenReturn(requestExecutor);
-        when(serviceLoader.onlyOne(ExecutionSynchronizer.class)).thenReturn(inspectionSynchronizer);
-        when(serviceLoader.onlyOne(WarpExecutor.class)).thenReturn(warpExecutor);
-        when(serviceLoader.onlyOne(WarpContext.class)).thenReturn(warpContext);
+        lenient().when(serviceLoader.onlyOne(ExecutionSynchronizer.class)).thenReturn(inspectionSynchronizer);
+        lenient().when(serviceLoader.onlyOne(WarpExecutor.class)).thenReturn(warpExecutor);
+        lenient().when(serviceLoader.onlyOne(WarpContext.class)).thenReturn(warpContext);
         when(serviceLoader.onlyOne(HttpFilterBuilder.class)).thenReturn(new DefaultHttpFilterBuilder());
 
         bind(ApplicationScoped.class, ServiceLoader.class, serviceLoader);

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/proxy/TestProxyURLToContextMapping.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/proxy/TestProxyURLToContextMapping.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestProxyURLToContextMapping {

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/separation/TestSeparatedClassLoader.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/separation/TestSeparatedClassLoader.java
@@ -33,6 +33,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.objenesis.ObjenesisStd;
+
+import net.bytebuddy.dynamic.loading.ClassInjector;
 
 @RunWith(SeparatedClassloaderRunner.class)
 public class TestSeparatedClassLoader {
@@ -43,10 +46,13 @@ public class TestSeparatedClassLoader {
             ClassLoaderUtils.class);
 
         JavaArchive mockito = ShrinkWrapUtils.getJavaArchiveFromClass(Mockito.class);
+        //Add mockito dependencies "bytebuddy" and "objenesis", otherwise "ClassNotFoundException" will be thrown when executing the test.
+        JavaArchive bytebuddy = ShrinkWrapUtils.getJavaArchiveFromClass(ClassInjector.class);
+        JavaArchive objenesis = ShrinkWrapUtils.getJavaArchiveFromClass(ObjenesisStd.class);
 
         JavaArchive junit = ShrinkWrapUtils.getJavaArchiveFromClass(Assert.class);
 
-        return new JavaArchive[] {archive, mockito, junit};
+        return new JavaArchive[] {archive, mockito, bytebuddy, objenesis, junit};
     }
 
     @Test

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/server/execution/TestHttpRequestProcessor.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/server/execution/TestHttpRequestProcessor.java
@@ -51,7 +51,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestHttpRequestProcessor extends AbstractWarpServerTestTestBase {

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/server/lifecycle/LifecycleManagerTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/server/lifecycle/LifecycleManagerTest.java
@@ -39,7 +39,7 @@ import org.jboss.arquillian.warp.spi.servlet.event.ProcessHttpRequest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author Lukas Fryc

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/server/lifecycle/ManagerBindingTestCase.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/server/lifecycle/ManagerBindingTestCase.java
@@ -36,7 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author Lukas Fryc

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/server/lifecycle/TestLifecycleTest.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/server/lifecycle/TestLifecycleTest.java
@@ -37,7 +37,7 @@ import org.jboss.arquillian.warp.spi.servlet.event.BeforeServlet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author Lukas Fryc

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/server/test/TestLifecycleTestDriver.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/server/test/TestLifecycleTestDriver.java
@@ -47,7 +47,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestLifecycleTestDriver extends AbstractWarpServerTestTestBase {
@@ -89,6 +89,11 @@ public class TestLifecycleTestDriver extends AbstractWarpServerTestTestBase {
     public void when_registry_contains_inspection_with_annotated_method__matching_current_lifecycle_event_then_method_is_fired() {
 
         // having
+        // Here is the reason why we use "mockito-inline": the mock maker "subclass" copies the annotations of the Inspection to the mock subclass.
+        // This would result in "LifecycleTestDriver.fireTest" calling the test methode twice (because "SecurityActions.getMethodsMatchingAllQualifiers" finds the method twice)
+        // A workaround could be to create the inspection this way:
+        // TestingInspection inspection = mock(TestingInspection.class, withSettings().withoutAnnotations());
+        // The issue does not happen with mock maker "inline".
         TestingInspection inspection = mock(TestingInspection.class);
         when(inspectionRegistry.getInspections()).thenReturn(Arrays.<Inspection>asList(inspection));
 
@@ -106,6 +111,7 @@ public class TestLifecycleTestDriver extends AbstractWarpServerTestTestBase {
     public void when_registry_contains_two_inspection_then_all_methods_are_executed() {
 
         // having
+        // will only work with "mockito-inline", see comment in "when_registry_contains_inspection_with_annotated_method__matching_current_lifecycle_event_then_method_is_fired"
         TestingInspection inspection1 = mock(TestingInspection.class);
         TestingInspectionForMultipleInspections inspection2 = mock(TestingInspectionForMultipleInspections.class);
         when(inspectionRegistry.getInspections()).thenReturn(Arrays.<Inspection>asList(inspection1, inspection2));
@@ -125,6 +131,7 @@ public class TestLifecycleTestDriver extends AbstractWarpServerTestTestBase {
     public void when_registry_contains_inspection_with_multiple_methods_annotated_with_given_lifecycle_event_annotation_then_all_methods_are_executed() {
 
         // having
+        // will only work with "mockito-inline", see comment in "when_registry_contains_inspection_with_annotated_method__matching_current_lifecycle_event_then_method_is_fired"
         TestingInspectionForMultipleMethods inspection = mock(TestingInspectionForMultipleMethods.class);
         when(inspectionRegistry.getInspections()).thenReturn(Arrays.<Inspection>asList(inspection));
 

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/server/test/TestLifecycleTestEnrichmentWatcher.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/server/test/TestLifecycleTestEnrichmentWatcher.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <!-- Tests -->
     <version.junit>4.13.1</version.junit>
     <version.hamcrest>1.3</version.hamcrest>
-    <version.mockito>1.10.19</version.mockito>
+    <version.mockito>4.9.0</version.mockito>
     <version.jacoco>0.8.8</version.jacoco>
     <version.shrinkwrap.resolver>3.1.4</version.shrinkwrap.resolver>
     <version.jboss_spec>3.0.3.Final</version.jboss_spec>


### PR DESCRIPTION
Updated Mockito from 1.10.19 to 4.9.0 (the latest version for Java 1.8) - which gave me a lot of headache ;-).

Changes:

- artifact "mockito-all" is discontinued since 2.0, replaced by "mockito-core".
- "org.mockito.runners.MockitoJUnitRunner" is deprecated, replaced by "org.mockito.junit.MockitoJUnitRunner"
- after updating, there were a few exceptions like this:
  ```
    org.mockito.exceptions.misusing.UnnecessaryStubbingException:
  
    Unnecessary stubbings detected in test class: TestRequestExecutionSynchronization
    Clean & maintainable test code requires zero unnecessary code.
    Following stubbings are unnecessary (click to navigate to relevant line of code):
      1. -> at org.jboss.arquillian.warp.impl.client.execution.TestRequestExecutionSynchronization.initialize(TestRequestExecutionSynchronization.java:110)
    Please remove unnecessary stubbings or use 'silent' option. More info: javadoc for UnnecessaryStubbingException class.
  ```
  workaround: prepend the "when()" method with "lenient().when()":
  ```
    lenient().when(serviceLoader.onlyOne(WarpRuntime.class)).thenReturn(warpRuntime);
  ```
  To my understanding, this "when" call is unnecessary, maybe even the full line of code could be removed. 
  What do you think?

- next  problem was a ClassNotFoundException in "org.jboss.arquillian.warp.impl.client.separation.TestSeparatedClassLoader":
  ```
  INFORMATION: Loaded test class: org.jboss.arquillian.warp.impl.client.separation.TestSeparatedClassLoader
  [ERROR] Tests run: 4, Failures: 0, Errors: 4, Skipped: 0, Time elapsed: 0.048 s <<< FAILURE! - in org.jboss.arquillian.warp.impl.client.separation.TestSeparatedClassLoader
  [ERROR] testClassLoaderNotFound(org.jboss.arquillian.warp.impl.client.separation.TestSeparatedClassLoader)  Time elapsed: 0.016 s  <<< ERROR!
  java.lang.IllegalStateException: Could not initialize plugin: interface org.mockito.plugins.MockMaker (alternate: null)
          at org.mockito.internal.configuration.plugins.PluginLoader$1.invoke(PluginLoader.java:74)
          at com.sun.proxy.$Proxy33.isTypeMockable(Unknown Source)
  ....
  Caused by: java.lang.ClassNotFoundException: net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection
          at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
          at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
          at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
          ... 52 more
  ```
  Resolution: also call "ShrinkWrapUtils.getJavaArchiveFromClass" for a class from "net-bytebuddy" and "objenesis" (dependencies of Mockito):
  
  ```
          JavaArchive mockito = ShrinkWrapUtils.getJavaArchiveFromClass(Mockito.class);
          JavaArchive bytebuddy = ShrinkWrapUtils.getJavaArchiveFromClass(net.bytebuddy.dynamic.loading.ClassInjector.class);
          JavaArchive objenesis = ShrinkWrapUtils.getJavaArchiveFromClass(org.objenesis.ObjenesisStd.class);
  
  ```
- Final problem was a "org.mockito.exceptions.verification.TooManyActualInvocations":
  ```
  [ERROR] Tests run: 6, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.146 s <<< FAILURE! - in org.jboss.arquillian.warp.impl.server.test.TestLifecycleTestDriver
  [ERROR] when_registry_contains_inspection_with_multiple_methods_annotated_with_given_lifecycle_event_annotation_then_all_methods_are_executed(org.jboss.arquillian.warp.impl.server.test.TestLifecycleTestDriver)  Time elapsed: 0 s  <<< FAILURE!
  org.mockito.exceptions.verification.TooManyActualInvocations:
  
  testingInspectionForMultipleMethods.test1();
  Wanted 1 time:
  -> at org.jboss.arquillian.warp.impl.server.test.TestLifecycleTestDriver.when_registry_contains_inspection_with_multiple_methods_annotated_with_given_lifecycle_event_annotation_then_all_methods_are_executed(TestLifecycleTestDriver.java:135)
  But was 2 times:
  -> at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  -> at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  ```
  Reason: the default mock maker "subclass" copies the annotations of the Inspection to the mock subclass (seems to be a change since 1.0.x). This would result in "LifecycleTestDriver.fireTest" calling the test methode twice (because "SecurityActions.getMethodsMatchingAllQualifiers" finds the method twice): on the real Inspection implementation and on the subclass that mockmaker created.
  A workaround could be to create the inspection this way (don't copy the annotation to the subclass):
  ```
  TestingInspection inspection = mock(TestingInspection.class, withSettings().withoutAnnotations());
  ```
  
  But I found that the issue does not happen with mock maker "inline", which will be the default mockmaker in 5.0.
  
  So I added another dependency on "mockito-inline":
  ```
      <dependency>
        <groupId>org.mockito</groupId>
        <artifactId>mockito-inline</artifactId>
        <scope>test</scope>
      </dependency>
  ```
  Is this OK for you?

- and a question: "api\pom.xml" declared a dependency "mockito-all". A "mvn clean install" runs also without those, so I assume it is not necessary. I uncommented the dependency in this pull request. What do you t hink.