### PR TITLE
Repairs the profile 'tomee-managed-1-6'

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,11 +34,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <!--seems to be unnessary...
+    <!--seems to be unnessary, but keep it in case it is needed... -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-    </dependency>-->
+    </dependency>
   </dependencies>
 </project>

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -32,7 +32,7 @@
     <arquillian.contaner.maxTestClassesBeforeRestart>50</arquillian.contaner.maxTestClassesBeforeRestart>
 
     <!-- Container Selection -->
-    <arquillian.launch.wildfly>true</arquillian.launch.wildfly>
+    <arquillian.launch.wildfly>false</arquillian.launch.wildfly>
     <arquillian.launch.tomcat6>false</arquillian.launch.tomcat6>
     <arquillian.launch.tomcat7>false</arquillian.launch.tomcat7>
     <arquillian.launch.tomee16>false</arquillian.launch.tomee16>

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -153,6 +153,11 @@
       </dependencies>
     </profile>
     <profile>
+      <!--
+        Note: to run this profile, an additional change has to be made in "extension/jsf-ftest/pom.xml".
+        Otherwise, the test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" will fail.
+        See explanation there.
+      -->
       <id>tomee-managed-1-6</id>
       <activation>
         <property>

--- a/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInstaller.java
+++ b/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInstaller.java
@@ -146,6 +146,11 @@ public class ContainerInstaller {
                     continue;
                 }
 
+                //Create parent directory if it does not exist. This happens when expanding "apache-tomee-1.7.5-webprofile.zip".
+                if (newFile.getParentFile().exists() == false) {
+                  newFile.getParentFile().mkdir();
+                }
+
                 if (newFile.exists() && overwrite) {
                     log.info("Overwriting " + newFile);
                     newFile.delete();

--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -24,11 +24,28 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!--
+        The test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" (see detailed explanation there)
+        will fail in profiles "tomee-managed" and "tomee-remote" with this error:
+
+        javax.servlet.ServletException : null [Proxied because : Original exception caused: class java.io.InvalidClassException: javax.servlet.ServletException;
+        local class incompatible: stream classdesc serialVersionUID = 1, local class serialVersionUID = 4221302886851315160]
+
+        Workaround: replace the dependency on the servlet spec from JBoss with a dependency on "org.apache.tomcat:tomcat-servlet-api".
+      -->
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.0_spec</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!--
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-servlet-api</artifactId>
+      <scope>provided</scope>
+      <version>7.0.81</version>
+    </dependency>
+    -->
     <dependency>
       <groupId>org.jboss.spec.javax.faces</groupId>
       <artifactId>jboss-jsf-api_2.1_spec</artifactId>

--- a/extension/jsf-ftest/src/main/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/FailingPhaseListener.java
+++ b/extension/jsf-ftest/src/main/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/FailingPhaseListener.java
@@ -26,12 +26,12 @@ public class FailingPhaseListener implements PhaseListener {
 
     @Override
     public void afterPhase(PhaseEvent event) {
-        throw new TestingException();
+        throw new TestingException("TestingException in afterPhase");
     }
 
     @Override
     public void beforePhase(PhaseEvent event) {
-        throw new TestingException();
+        throw new TestingException("TestingException in beforePhase");
     }
 
     @Override
@@ -40,6 +40,10 @@ public class FailingPhaseListener implements PhaseListener {
     }
 
     public static class TestingException extends RuntimeException {
+
+        public TestingException(String message) {
+            super(message);
+        }
 
         private static final long serialVersionUID = 1L;
     }

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestFacesLifecycleFailurePropagation.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestFacesLifecycleFailurePropagation.java
@@ -83,6 +83,35 @@ import org.openqa.selenium.WebDriver;
 @RunWith(Arquillian.class)
 public class TestFacesLifecycleFailurePropagation {
 
+    /**
+     * This test will fail in the profiles "tomee-managed" and "tomee-remote" with this error:
+     *
+     * javax.servlet.ServletException : null [Proxied because : Original exception caused: class java.io.InvalidClassException: javax.servlet.ServletException;
+     * local class incompatible: stream classdesc serialVersionUID = 1, local class serialVersionUID = 4221302886851315160]
+     *
+     * Reason (see https://github.com/arquillian/arquillian-extension-warp/pull/108#issuecomment-1475388798):
+     * extension/jsf-ftest/pom.xml declares a dependency "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec", where
+     * no serialVersionUID is defined on "ServletException".
+     * The TomEE implementation of "ServletException" from org.apache.tomcat:tomcat-servlet-api defines a serialVersionUID = 1.
+     * This causes the error.
+     *
+     * Workaround: replace this in extension/jsf-ftest/pom.xml
+     *     <dependency>
+     *       <groupId>org.jboss.spec.javax.servlet</groupId>
+     *       <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+     *       <scope>provided</scope>
+     *     </dependency>
+     *
+     * with this:
+     *
+     *     <dependency>
+     *       <groupId>org.apache.tomcat</groupId>
+     *       <artifactId>tomcat-servlet-api</artifactId>
+     *       <scope>provided</scope>
+     *       <version>...version of TomEE...</version>
+     *     </dependency>
+     */
+
     @Drone
     WebDriver browser;
 

--- a/ftest/src/main/java/org/jboss/arquillian/warp/ftest/FormServlet.java
+++ b/ftest/src/main/java/org/jboss/arquillian/warp/ftest/FormServlet.java
@@ -29,6 +29,11 @@ import java.io.PrintWriter;
  */
 @WebServlet("/form")
 public class FormServlet extends HttpServlet {
+    /**
+     * Eclipse requires a serialVersionUID.
+     */
+    private static final long serialVersionUID = 1L;
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.setContentType("text/html");
@@ -36,7 +41,20 @@ public class FormServlet extends HttpServlet {
         PrintWriter out = resp.getWriter();
 
         writeStart(out);
-        out.write("<form action=\"http://127.0.0.1:8080/test/form\" method=\"post\">\n");
+
+        //TomEE does not replace "127.0.0.1:8080" with the Warp proxy URL, which makes "org.jboss.arquillian.warp.ftest.http.TestResponseContainsProxyUrl" fail.
+        //But "localhost:8080" works.
+        //With WildFly, it is vice versa.
+        //So evaluate the server info:
+        //WildFly 26: "WildFly Full 26.1.3.Final (WildFly Core 18.1.2.Final) - 2.2.19.Final"
+        //TomEE 1.7.5: "Apache Tomcat (TomEE)/7.0.81 (1.7.5)"
+        String serverInfo = this.getServletContext().getServerInfo();
+        if (serverInfo.contains("TomEE") == true) {
+            out.write("<form action=\"http://localhost:8080/test/form\" method=\"post\">\n");
+        }
+        else {
+            out.write("<form action=\"http://127.0.0.1:8080/test/form\" method=\"post\">\n");
+        }
         out.write("<input type=\"submit\" id=\"submit\" />\n");
         out.write("</form>\n");
         writeEnd(out);

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <version.tomcat6>6.0.35</version.tomcat6>
     <version.tomcat7>7.0.26</version.tomcat7>
     <version.wildfly>26.1.3.Final</version.wildfly>
-    <!--Don't upgrade beyond 2.2.0.Final. 4.0.0.Alpha6 fails, and 5.0.0.Alpha6 is built with Java 11 -->
+    <!--Don't upgrade beyond 3.0.1.Final. 4.0.0.Alpha6 fails, and 5.0.0.Alpha6 is built with Java 11 -->
     <version.wildfly.arquillian.container>3.0.1.Final</version.wildfly.arquillian.container>
 
     <additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
First some cleanup of older pull requests:

- uncomment "mockito-core" dependeny in "api/pom.xml" aus you suggested in #105
- updates the comment before "version.wildfly.arquillian.container" to match the current version (#104)
- set "arquillian.launch.wildfly" to "false" in "build/ftest-base/pom.xml" again - I changed it with #102 and this makes other profiles fail ("Multiple Containers defined as default, only one is allowed")

Now the changes for the "tomee-managed-1-6" profile:
- First there is an error in "build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInstaller":
  
  ```
  java.lang.IllegalStateException: Can't unzip input stream
  ...
  Caused by: java.io.FileNotFoundException: C:\Temp\github\arquillian-extension-warp\ftest\target\apache-tomee-webprofile-1.7.5\webapps\docs\websocketapi\index.html (Das System kann den angegebenen Pfad nicht finden)
          at java.io.FileOutputStream.open0(Native Method)
          at java.io.FileOutputStream.open(FileOutputStream.java:270)
          at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
          at java.io.FileOutputStream.<init>(FileOutputStream.java:162)
          at org.arquillian.warp.ftest.installation.ContainerInstaller.unzip(ContainerInstaller.java:154)
          ... 32 more
  ```
  
  
  Solution: create the parent directory of a file that is to be unzipped, if it does not exist.
  
  ```
  if (newFile.getParentFile().exists() == false) {
    newFile.getParentFile().mkdir();
  }
  ```

- Next error is in "org.jboss.arquillian.warp.ftest.http.TestResponseContainsProxyUrl":

  ```
  [ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.545 s <<< FAILURE! - in org.jboss.arquillian.warp.ftest.http.TestResponseContainsProxyUrl
  [ERROR] test(org.jboss.arquillian.warp.ftest.http.TestResponseContainsProxyUrl)  Time elapsed: 0.255 s  <<< FAILURE!
  java.lang.AssertionError:
  
  Expected: a string containing "http://127.0.0.1:5130/test/"
       but: was "<?xml version="1.0" encoding="ISO-8859-1"?>
  <html>
    <head>
      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
    </head>
    <body>
      <form action="http://127.0.0.1:8080/test/form" method="post">
        <input type="submit" id="submit"/>
      </form>
    </body>
  </html>
  "
  ```
  
  Workaround: in "ftest/src/main/java/org/jboss/arquillian/warp/ftest/FormServlet.java", replace the url "http://127.0.0.1:8080/test/form" with "http://localhost:8080/test/form" for TomEE.
  WildFly unfortunately requires "127.0.0.1" and fails with "localhost". So I set the url depending on the server info:

  ```
        String serverInfo = this.getServletContext().getServerInfo();
        if (serverInfo.contains("TomEE") == true) {
          out.write("<form action=\"http://localhost:8080/test/form\" method=\"post\">\n");
        }
        else {
          out.write("<form action=\"http://127.0.0.1:8080/test/form\" method=\"post\">\n");
        }
  ```


Now there is one error remaining in "extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestFacesLifecycleFailurePropagation.java", where I don't know how to fix it or work around it.
Probably this is related to the fact the "myfaces" is the TomEE JSF implementation, which is different to the WildFly implementation.

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.013 s <<< FAILURE! - in org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation
[ERROR] test(org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation)  Time elapsed: 0.346 s  <<< ERROR!
java.lang.Exception: Unexpected exception, expected<org.jboss.arquillian.warp.exception.ServerWarpExecutionException> but was<org.jboss.arquillian.test.spi.ArquillianProxyException>
        at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:30)
        at org.jboss.arquillian.junit.Arquillian$4.evaluate(Arquillian.java:204)
        ...
Caused by: org.jboss.arquillian.test.spi.ArquillianProxyException: javax.servlet.ServletException : null [Proxied because : Original exception caused: class java.io.InvalidClassException: javax.servlet.ServletException; local class incompatible: stream classdesc serialVersionUID = 1, local class serialVersionUID = 4221302886851315160]
        at javax.faces.webapp.FacesServlet.service(FacesServlet.java:230)
        at org.apache.tomee.myfaces.TomEEWorkaroundFacesServlet.service(TomEEWorkaroundFacesServlet.java:47)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
        ...
Caused by: org.jboss.arquillian.warp.jsf.ftest.lifecycle.FailingPhaseListener$TestingException
        at org.jboss.arquillian.warp.jsf.ftest.lifecycle.FailingPhaseListener.beforePhase(FailingPhaseListener.java:34)
        at org.apache.myfaces.lifecycle.PhaseListenerManager.informPhaseListenersBefore(PhaseListenerManager.java:77)
        at org.apache.myfaces.lifecycle.LifecycleImpl.executePhase(LifecycleImpl.java:184)
        at org.apache.myfaces.lifecycle.LifecycleImpl.execute(LifecycleImpl.java:143)
        at javax.faces.webapp.FacesServlet.service(FacesServlet.java:198)
        ... 72 more
```

But I want to commit at least what I have done up to now. If I find a solution in the next few days, I will send another pull request or add it to this one has not been accepted.

I also tried to update to TomEE7, but the same error occured. So, I would prefer to fix TomEE 1.7 before making further changes.