### PR TITLE
Updated TomEE to 8.0.14, removed profile tomee-remote-1-6

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -35,7 +35,7 @@
     <arquillian.launch.wildfly>false</arquillian.launch.wildfly>
     <arquillian.launch.tomcat6>false</arquillian.launch.tomcat6>
     <arquillian.launch.tomcat7>false</arquillian.launch.tomcat7>
-    <arquillian.launch.tomee16>false</arquillian.launch.tomee16>
+    <arquillian.launch.tomee>false</arquillian.launch.tomee>
     <arquillian.launch.glassfish40>false</arquillian.launch.glassfish40>
   </properties>
 
@@ -158,47 +158,26 @@
         Otherwise, the test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" will fail.
         See explanation there.
       -->
-      <id>tomee-managed-1-6</id>
+      <id>tomee-managed</id>
       <activation>
         <property>
           <name>integration</name>
-          <value>tomee16</value>
+          <value>tomee</value>
         </property>
       </activation>
       <properties>
-        <arquillian.launch.tomee16>true</arquillian.launch.tomee16>
+        <arquillian.launch.tomee>true</arquillian.launch.tomee>
         <arquillian.richfaces.jsfProvider>myfaces</arquillian.richfaces.jsfProvider>
-        <arquillian.container.home>${project.build.directory}/apache-tomee-webprofile-${version.tomee16}
+        <arquillian.container.home>${project.build.directory}/apache-tomee-webprofile-${version.tomee}
         </arquillian.container.home>
-        <arquillian.container.distribution>org.apache.openejb:apache-tomee:zip:webprofile:${version.tomee16}
+        <arquillian.container.distribution>org.apache.tomee:apache-tomee:zip:webprofile:${version.tomee}
         </arquillian.container.distribution>
       </properties>
       <dependencies>
         <dependency>
-          <groupId>org.apache.openejb</groupId>
+          <groupId>org.apache.tomee</groupId>
           <artifactId>arquillian-tomee-remote</artifactId>
-          <version>${version.tomee16}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>tomee-remote-1-6</id>
-      <activation>
-        <property>
-          <name>integration</name>
-          <value>tomee16-remote</value>
-        </property>
-      </activation>
-      <properties>
-        <arquillian.launch.tomee16>true</arquillian.launch.tomee16>
-        <arquillian.richfaces.jsfProvider>myfaces</arquillian.richfaces.jsfProvider>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.openejb</groupId>
-          <artifactId>arquillian-tomee-remote</artifactId>
-          <version>${version.tomee16}</version>
+          <version>${version.tomee}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/build/resources/src/main/resources/arquillian.xml
+++ b/build/resources/src/main/resources/arquillian.xml
@@ -58,11 +58,11 @@
     </configuration>
   </container>
 
-  <container qualifier="tomee16" default="${arquillian.launch.tomee16}">
+  <container qualifier="tomee" default="${arquillian.launch.tomee}">
     <configuration>
       <property name="httpPort">8080</property>
       <property name="stopPort">9005</property>
-      <property name="version">${version.tomee16}</property>
+      <property name="version">${version.tomee}</property>
       <property name="dir">${arquillian.container.home}</property>
       <property name="appWorkingDir">target/arquillian-test-working-dir</property>
       <property name="javaVmArguments">${arquillian.container.vmargs}</property>

--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <!--
         The test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" (see detailed explanation there)
-        will fail in profiles "tomee-managed" and "tomee-remote" with this error:
+        will fail in profile "tomee-managed" with this error:
 
         javax.servlet.ServletException : null [Proxied because : Original exception caused: class java.io.InvalidClassException: javax.servlet.ServletException;
         local class incompatible: stream classdesc serialVersionUID = 1, local class serialVersionUID = 4221302886851315160]

--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -43,7 +43,7 @@
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-servlet-api</artifactId>
       <scope>provided</scope>
-      <version>7.0.81</version>
+      <version>${version.tomee}</version>
     </dependency>
     -->
     <dependency>

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestFacesLifecycleFailurePropagation.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestFacesLifecycleFailurePropagation.java
@@ -84,7 +84,7 @@ import org.openqa.selenium.WebDriver;
 public class TestFacesLifecycleFailurePropagation {
 
     /**
-     * This test will fail in the profiles "tomee-managed" and "tomee-remote" with this error:
+     * This test will fail in the profile "tomee-managed" with this error:
      *
      * javax.servlet.ServletException : null [Proxied because : Original exception caused: class java.io.InvalidClassException: javax.servlet.ServletException;
      * local class incompatible: stream classdesc serialVersionUID = 1, local class serialVersionUID = 4221302886851315160]
@@ -108,7 +108,7 @@ public class TestFacesLifecycleFailurePropagation {
      *       <groupId>org.apache.tomcat</groupId>
      *       <artifactId>tomcat-servlet-api</artifactId>
      *       <scope>provided</scope>
-     *       <version>...version of TomEE...</version>
+     *       <version>${version.tomee}</version>
      *     </dependency>
      */
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <version.jboss_spec>3.0.3.Final</version.jboss_spec>
 
     <!-- Container Versions -->
-    <version.tomee16>1.7.5</version.tomee16>
+    <version.tomee>8.0.14</version.tomee>
     <version.glassfish40>4.0</version.glassfish40>
     <version.tomcat6>6.0.35</version.tomcat6>
     <version.tomcat7>7.0.26</version.tomcat7>


### PR DESCRIPTION
This pull request updates TomEE to 8.0.14, the latest JakartaEE 8 version. TomEE 9 is based on JakartaEE9.

Also, I removed the profile "tomee-remote-1-6", as there is no remote adapter (as exists for WildFly), see [https://tomee.apache.org/tomee-9.0/docs/arquillian-available-adapters.html](https://tomee.apache.org/tomee-9.0/docs/arquillian-available-adapters.html). There is only an embedded adapter. The previous "tomee-remote-1-6" profile behaved the same as the managed profile, with the only difference that the TomEE server was downloaded to a default directory.