### PR TITLE
Fixes tests for GlassFish 4, move ContainerInstaller.uninstallContainer from AfterSuite to AfterStop

### DIFF
--- a/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInitializationObserver.java
+++ b/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInitializationObserver.java
@@ -16,11 +16,11 @@
  */
 package org.arquillian.warp.ftest.installation;
 
+import org.jboss.arquillian.container.spi.event.container.AfterStop;
 import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.spi.EventContext;
-import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
 import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
 
 public class ContainerInitializationObserver {
@@ -40,7 +40,14 @@ public class ContainerInitializationObserver {
         ctx.proceed();
     }
 
-    public void uninstallContainer(@Observes(precedence = 400) EventContext<AfterSuite> ctx) {
+    /**
+     * Removes a managed container from the "target" directory.
+     *
+     * This must happen after the container was stopped, not in "AfterSuite" event (which seems to be fired before the container is stopped).
+     *
+     * @param ctx
+     */
+    public void uninstallContainer(@Observes(precedence = 400) EventContext<AfterStop> ctx) {
         uninstall.fire(new UninstallContainer());
     }
 }

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceNotFound.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceNotFound.java
@@ -51,7 +51,11 @@ public class TestJSFResourceNotFound {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "jsf-test.war")
-            .addAsWebInfResource(new StringAsset("<faces-config version=\"2.0\" xmlns=\"http://java.sun.com/xml/ns/javaee\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd\"></faces-config>"), "faces-config.xml");
+            .addAsWebInfResource(new StringAsset("<faces-config version=\"2.0\" xmlns=\"http://java.sun.com/xml/ns/javaee\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd\"></faces-config>"), "faces-config.xml")
+            //The test for GlassFish will fail without "web.xml" with a "java.io.IOException: Server returned HTTP response code: 500 for URL: http://127.0.0.1:10186/jsf-test/faces/notExisting.xhtml"
+            //instead of the expected "FileNotFoundException".
+            //On other servers, it works as expected.
+            .addAsWebInfResource(new java.io.File("src/main/webapp/WEB-INF/web.xml"));
     }
 
     @Test

--- a/ftest/src/main/java/org/jboss/arquillian/warp/ftest/FormServlet.java
+++ b/ftest/src/main/java/org/jboss/arquillian/warp/ftest/FormServlet.java
@@ -42,14 +42,15 @@ public class FormServlet extends HttpServlet {
 
         writeStart(out);
 
-        //TomEE does not replace "127.0.0.1:8080" with the Warp proxy URL, which makes "org.jboss.arquillian.warp.ftest.http.TestResponseContainsProxyUrl" fail.
+        //TomEE and Glassfish do not replace "127.0.0.1:8080" with the Warp proxy URL, which makes "org.jboss.arquillian.warp.ftest.http.TestResponseContainsProxyUrl" fail.
         //But "localhost:8080" works.
         //With WildFly, it is vice versa.
         //So evaluate the server info:
         //WildFly 26: "WildFly Full 26.1.3.Final (WildFly Core 18.1.2.Final) - 2.2.19.Final"
         //TomEE 1.7.5: "Apache Tomcat (TomEE)/7.0.81 (1.7.5)"
+        //Glassfish 4: "GlassFish Server Open Source Edition  4.0"
         String serverInfo = this.getServletContext().getServerInfo();
-        if (serverInfo.contains("TomEE") == true) {
+        if (serverInfo.contains("TomEE") == true || serverInfo.contains("GlassFish") == true) {
             out.write("<form action=\"http://localhost:8080/test/form\" method=\"post\">\n");
         }
         else {


### PR DESCRIPTION
Besides repairing two tests that failed on GlassFish, this pull request makes one change to "ContainerInstaller.uninstallContainer" or rather "ContainerInitializationObserver.uninstallContainer": In my first pull request I already noticed that deletion of the managed container failed, and added a logging output: https://github.com/arquillian/arquillian-extension-warp/pull/84/files#r1110317632
But for GlassFish, this causes bigger trouble because after the first block of tests from the "ftest" project the server is not stopped, and thus the tests from "extension\jsf-ftest" will fail to start another server => you have to kill the java process yourself.

The reason is that "ContainerInstaller.uninstallContainer" is called before the " GlassFishManagedDeployableContainer.stop", as you see in the log below. "uninstallContainer" removes the container only partially, but the batch files required to stop the server are deleted. So the "stop" call fails:

```
Mär 23, 2023 9:30:46 PM org.arquillian.warp.ftest.installation.ContainerInstaller uninstallContainer
INFORMATION: The container will be uninstalled from 'C:\Temp\github\arquillian-extension-warp\extension\jsf-ftest\target\glassfish4'
Mär 23, 2023 9:30:46 PM org.arquillian.warp.ftest.installation.ContainerInstaller uninstallContainer
SCHWERWIEGEND: could not delete container from 'C:\Temp\github\arquillian-extension-warp\extension\jsf-ftest\target\glassfish4'
Mär 23, 2023 9:30:46 PM org.jboss.arquillian.container.glassfish.managed_3_1.GlassFishServerControl$1 run
WARNUNG: Forcing container shutdown
Stopping container using command: [java, -jar, C:\Temp\github\arquillian-extension-warp\extension\jsf-ftest\target\glassfish4\glassfish\modules\admin-cli.jar, stop-domain, -t]
Can't find the default domains directory.  There is no value for this system property: com.sun.aas.domainsRoot
```

My workaround: instead of:
```
    public void uninstallContainer(@Observes(precedence = 400) EventContext<AfterSuite> ctx) {
```
I moved it to "AfterStop":
```
    public void uninstallContainer(@Observes(precedence = 400) EventContext<AfterStop> ctx) {
        uninstall.fire(new UninstallContainer());
    }
```


Now the changes for GlassFish 4:

- The test "org.jboss.arquillian.warp.ftest.http.TestResponseContainsProxyUrl" produces the same error that I fixed for TomEE in pull request #108: the url in the servlet form must be "http://localhost:8080" instead of "http://127.0.0.1:8080".
- The test "org.jboss.arquillian.warp.jsf.ftest.producer.TestJSFResourceNotFound" fails with:
   `org.jboss.arquillian.test.spi.ArquillianProxyException: com.sun.faces.context.FacesFileNotFoundException : /notExisting.xhtml Not Found in ExternalContext as a Resource [Proxied because : Original exception caused: class java.lang.ClassNotFoundException: com.sun.faces.context.FacesFileNotFoundException]`
   This ClassNotFoundException could be fixed by adding a dependency "org.glassfish:javax.faces:2.2.0" to the profile. But then another error happens:
   `org.jboss.arquillian.warp.exception.ServerWarpExecutionException:
The error occured during server request processing:
/notExisting.xhtml Not Found in ExternalContext as a Resource`
   This is not the "java.io.FileNotFoundException" that the Activity of the test expects, but a "java.io.IOException". 

   The reason seems to be that JSF is not initialized properly. I could fix it by adding a "web.xml" to the deployed war file:

   ```
   public class TestJSFResourceNotFound {
   
       @Deployment
       public static WebArchive createDeployment() {
           return ShrinkWrap.create(WebArchive.class, "jsf-test.war")
               .addAsWebInfResource(new StringAsset("<faces-config version=\"2.0\" xmlns=\"http://java.sun.com/xml/ns/javaee\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd\"></faces-config>"), "faces-config.xml")
               .addAsWebInfResource(new java.io.File("src/main/webapp/WEB-INF/web.xml"));
       }
   ```
   Now the test catches the expected FileNotFoundException.