### PR TITLE
Updated LittleProxy to 1.1.2, fixed API changes, added 'withAllowRequestToOriginServer' to proxy initialization

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/DefaultHttpFiltersSource.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/DefaultHttpFiltersSource.java
@@ -62,7 +62,7 @@ public class DefaultHttpFiltersSource extends HttpFiltersSourceAdapter {
             private HttpRequest request;
 
             @Override
-            public HttpResponse requestPost(HttpObject httpObject) {
+            public HttpResponse proxyToServerRequest(HttpObject httpObject) {
 
                 final WarpContext context = WarpContextStore.get();
 
@@ -93,7 +93,7 @@ public class DefaultHttpFiltersSource extends HttpFiltersSourceAdapter {
             }
 
             @Override
-            public HttpObject responsePost(HttpObject httpObject) {
+            public HttpObject proxyToClientResponse(HttpObject httpObject) {
 
                 try {
                     if (this.request instanceof HttpRequest && httpObject instanceof HttpResponse) {

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/proxy/DefaultProxyService.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/proxy/DefaultProxyService.java
@@ -87,6 +87,8 @@ public class DefaultProxyService implements ProxyService<HttpProxyServer> {
                 }
             })
             .withFiltersSource(httpFiltersSource)
+            //Required by LittleProxy 1.1.2 - otherwise "proxyToServerRequest" is never called.
+            .withAllowRequestToOriginServer(true)
             .start();
     }
 

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/utils/BaseNCodec.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/utils/BaseNCodec.java
@@ -19,8 +19,6 @@ package org.jboss.arquillian.warp.impl.utils;
 
 import java.io.UnsupportedEncodingException;
 
-import org.apache.commons.codec.DecoderException;
-
 /**
  * Abstract superclass for Base-N encoders and decoders.
  *
@@ -268,11 +266,11 @@ public abstract class BaseNCodec {
 
     /**
      * Decodes an Object using the Base-N algorithm. This method is provided in order to satisfy the requirements of the Decoder
-     * interface, and will throw a DecoderException if the supplied object is not of type byte[] or String.
+     * interface, and will throw a IllegalStateException if the supplied object is not of type byte[] or String.
      *
      * @param pObject Object to decode
      * @return An object (of type byte[]) containing the binary data which corresponds to the byte[] or String supplied.
-     * @throws DecoderException if the parameter supplied is not of type byte[]
+     * @throws IllegalStateException if the parameter supplied is not of type byte[]
      */
     public Object decode(Object pObject) throws IllegalStateException {
         if (pObject instanceof byte[]) {

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <version.arquillian_drone>3.0.0-alpha.7</version.arquillian_drone>
     <version.arquillian_jacoco>1.1.0</version.arquillian_jacoco>
 
-    <version.littleproxy>1.0.0-beta5</version.littleproxy>
+    <version.littleproxy>1.1.2</version.littleproxy>
     <version.javassist>3.12.1.GA</version.javassist>
 
     <!-- Tests -->


### PR DESCRIPTION
This pull request supersedes #52

The original LittleProxy implementation from https://github.com/adamfisk/LittleProxy is no longer maintained, but there seems to be kind of "official" fork: https://github.com/LittleProxy/LittleProxy - so after this request is accepted, I will try to switch to this one.

There were two API changes/compilation errors after this change:
1) in "impl/src/main/java/org/jboss/arquillian/warp/impl/utils/BaseNCodec.java", the import for "DecoderException" no longer compiles. But as this one was used only in a JavaDoc comment, it can be removed.

2) in "impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/DefaultHttpFiltersSource.java", there was a rename of methods. Those are the commits that match old and new names: https://github.com/adamfisk/LittleProxy/commit/5b74f1ed9c062bb378b9fd8c8af6f9c496cb6a6a#diff-f22b4ae12a77d36cac4fb6ec02092061014c78125f6fa9b28b9015c263fcced4 and https://github.com/adamfisk/LittleProxy/commit/dae3005d3ca6940803be008830bdc94ebae03b7d#diff-f22b4ae12a77d36cac4fb6ec02092061014c78125f6fa9b28b9015c263fcced4

   - "requestPost" was changed to "proxyToServerRequest"
   - "responsePost" was changed to "proxyToClientResponse"


After applying this change, there was a runtime error. The reason was that "proxyToServerRequest" was never called, and thus the warp request enrichment did not happen. The first step "clientToProxyRequest" of the proxy filter chain (which is not implemented in the warp filter) was still called.
Unfortunately, I could not manage to enable LittleProxy logging, though there are config fragment in several "log4.properties" files in the warp extension.
By fishing in troubled waters and by looking the LittleProxy source code, I found a workaround: In "impl/src/main/java/org/jboss/arquillian/warp/impl/client/proxy/DefaultProxyService.java", I added "withAllowRequestToOriginServer" to the "DefaultHttpProxyServer" initialization:


```
        return DefaultHttpProxyServer
            .bootstrap()
            ...
            .withAllowRequestToOriginServer(true)
            .start();
```
The JavaDoc of this method says:

_When true, the proxy will accept requests that appear to be directed at an origin server (i.e. the URI in the HTTP request will contain an origin-form, rather than an absolute-form, as specified in RFC 7230, section 5.3 - https://www.rfc-editor.org/rfc/rfc7230#section-5.3.1).
This is useful when the proxy is acting as a gateway/reverse proxy. 
Note: This feature should not be enabled when running as a forward proxy; doing so may cause an infinite loop if the client requests the URI of the proxy._

I am not sure whether this change makes sense and does not cause other problems. So, please verify my changes thoroughly before merging the pull request ;-)