### PR TITLE
Switched to LittleProxy fork and updated to 2.0.5 (again...)

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -69,7 +69,7 @@
 
       <!-- LittleProxy -->
       <dependency>
-        <groupId>org.littleshoot</groupId>
+        <groupId>xyz.rogfam</groupId>
         <artifactId>littleproxy</artifactId>
         <version>${version.littleproxy}</version>
       </dependency>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -52,7 +52,7 @@
 
     <!-- Little Proxy -->
     <dependency>
-      <groupId>org.littleshoot</groupId>
+      <groupId>xyz.rogfam</groupId>
       <artifactId>littleproxy</artifactId>
     </dependency>
 

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/DefaultResponseTransformationService.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/DefaultResponseTransformationService.java
@@ -20,9 +20,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpUtil;
 
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -85,10 +85,10 @@ public class DefaultResponseTransformationService implements HttpResponseTransfo
                 transformedContent.writeBytes(bytes);
 
                 DefaultFullHttpResponse transformedResponse =
-                    new DefaultFullHttpResponse(fullResponse.getProtocolVersion(),
-                        fullResponse.getStatus(), transformedContent);
+                    new DefaultFullHttpResponse(fullResponse.protocolVersion(),
+                        fullResponse.status(), transformedContent);
                 transformedResponse.headers().set(fullResponse.headers());
-                HttpHeaders.setContentLength(transformedResponse, bytes.length);
+                HttpUtil.setContentLength(transformedResponse, bytes.length);
 
                 return transformedResponse;
             }

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/HttpRequestWrapper.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/HttpRequestWrapper.java
@@ -50,17 +50,17 @@ public class HttpRequestWrapper implements org.jboss.arquillian.warp.client.filt
 
     @Override
     public HttpMethod getMethod() {
-        return HttpMethod.valueOf(request.getMethod().name());
+        return HttpMethod.valueOf(request.method().name());
     }
 
     @Override
     public String getUri() {
-        return request.getUri();
+        return request.uri();
     }
 
     @Override
     public URL getUrl() {
-        return URLUtils.buildUrl(request.getUri());
+        return URLUtils.buildUrl(request.uri());
     }
 
     @Override
@@ -94,13 +94,13 @@ public class HttpRequestWrapper implements org.jboss.arquillian.warp.client.filt
 
     @Override
     public String toString() {
-        return String.format("%s %s", request.getMethod(), request.getUri());
+        return String.format("%s %s", request.method(), request.uri());
     }
 
     @Override
     public Map<String, List<String>> getQueryParameters() {
         if (queryParameters == null) {
-            QueryStringDecoder queryStringDecoder = new QueryStringDecoder(request.getUri());
+            QueryStringDecoder queryStringDecoder = new QueryStringDecoder(request.uri());
             queryParameters = queryStringDecoder.parameters();
         }
         return Collections.unmodifiableMap(queryParameters);

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/proxy/DefaultProxyService.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/proxy/DefaultProxyService.java
@@ -35,6 +35,7 @@ import org.littleshoot.proxy.ChainedProxyManager;
 import org.littleshoot.proxy.HttpFilters;
 import org.littleshoot.proxy.HttpFiltersSource;
 import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.ClientDetails;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 /**
@@ -77,7 +78,7 @@ public class DefaultProxyService implements ProxyService<HttpProxyServer> {
             .withChainProxyManager(new ChainedProxyManager() {
 
                 @Override
-                public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies) {
+                public void lookupChainedProxies(HttpRequest httpRequest, Queue<ChainedProxy> chainedProxies, ClientDetails clientDetails) {
                     chainedProxies.add(new ChainedProxyAdapter() {
                         @Override
                         public InetSocketAddress getChainedProxyAddress() {

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <version.arquillian_drone>3.0.0-alpha.7</version.arquillian_drone>
     <version.arquillian_jacoco>1.1.0</version.arquillian_jacoco>
 
-    <version.littleproxy>1.1.2</version.littleproxy>
+    <version.littleproxy>2.0.5</version.littleproxy>
     <!--Littleproxy logging is done through SL4J and thus Log4j: -->
     <version.log4j>2.20.0</version.log4j>
     <version.javassist>3.12.1.GA</version.javassist>


### PR DESCRIPTION
Sorry, but as I failed the rebase, this is the same as pull request #121

The original LittleProxy repository ([https://github.com/adamfisk/LittleProxy](https://github.com/adamfisk/LittleProxy)) is abandoned, but there is an active fork at [https://github.com/LittleProxy/LittleProxy](https://github.com/LittleProxy/LittleProxy)

This pull request switches to the new fork and version 2.0.5. One compilation error and a few deprecated warnings (from Netty) had to be fixed.

I cannot switch to newer LittleProxy versions - they cause a deadlock in the server side of the test "org.jboss.arquillian.warp.ftest.observer.TestHttpParameterFiltering" (in "org.jboss.arquillian.warp.ftest.TestingServlet.doPost"). Seems to be caused by the netty version referenced by LittleProxy - with 4.1.63.Final it works, with 4.1.65.Final the error occurs.
Here is my question in the LittleProxy forum: [https://groups.google.com/g/littleproxy2/c/ket_eIwcPFM/m/rwtVTbZNBAAJ](https://groups.google.com/g/littleproxy2/c/ket_eIwcPFM/m/rwtVTbZNBAAJ)