### PR TITLE
[ARQ-2216] switch to org.javassist:javassist and update to 3.29.2-GA

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -76,7 +76,7 @@
 
       <!-- Javassist -->
       <dependency>
-        <groupId>javassist</groupId>
+        <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
         <version>${version.javassist}</version>
       </dependency>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -58,7 +58,7 @@
 
     <!-- Javasist -->
     <dependency>
-      <groupId>javassist</groupId>
+      <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
     </dependency>
 

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/transformation/TransformedInspection.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/transformation/TransformedInspection.java
@@ -145,7 +145,8 @@ public class TransformedInspection {
     @SuppressWarnings("unchecked")
     private Class<Inspection> toClass() throws InspectionTransformationException {
         try {
-            return transformed.toClass();
+            //Should print a warning with Java 11.
+            return (Class<Inspection>) transformed.toClass();
         } catch (Exception e) {
             throw new InspectionTransformationException("Unable to convert " + transformed.getName() + " to class", e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <version.littleproxy>2.0.5</version.littleproxy>
     <!--Littleproxy logging is done through SL4J and thus Log4j: -->
     <version.log4j>2.20.0</version.log4j>
-    <version.javassist>3.12.1.GA</version.javassist>
+    <version.javassist>3.29.2-GA</version.javassist>
 
     <!-- Tests -->
     <version.junit>4.13.1</version.junit>


### PR DESCRIPTION
This fixes [https://issues.redhat.com/browse/ARQ-2216](https://issues.redhat.com/browse/ARQ-2216): executing a warp test with Java 11 or newer fails with a `javassist.NotFoundException`. 
The original "javassist:javassist" artifact was renamed to "org.javassist:javassist".