### PR TITLE
Removed vm arg MaxPermSize

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -27,7 +27,7 @@
     <arquillian.container.distribution />
     <arquillian.container.configuration />
     <arquillian.container.uninstall>true</arquillian.container.uninstall>
-    <arquillian.container.vmargs>-Xmx768m -XX:MaxPermSize=256m -Darquillian.debug=${arquillian.debug}
+    <arquillian.container.vmargs>-Xmx768m -Darquillian.debug=${arquillian.debug}
     </arquillian.container.vmargs>
     <arquillian.contaner.maxTestClassesBeforeRestart>50</arquillian.contaner.maxTestClassesBeforeRestart>
 


### PR DESCRIPTION
When starting a managed server, this message was printed:

```
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0`
```

Thus this pull request removes the option "-XX:MaxPermSize=256m" 
