### PR TITLE
Fixed ServletException serialVersionUID error for TomEE profile

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -233,13 +233,12 @@
         </dependency>
         <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
             test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
-            Here we could also use the JBoss implementation.
+            Here we use the JBoss implementation instead of the one of GlassFish, as it works as well and is easier to configure.
           -->
         <dependency>
-          <groupId>javax.servlet</groupId>
-          <artifactId>javax.servlet-api</artifactId>
+          <groupId>org.jboss.spec.javax.servlet</groupId>
+          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
           <scope>provided</scope>
-          <version>${version.glassfish40_servlet_api}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -263,12 +262,12 @@
         </dependency>
         <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
             test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
+            Here we use the JBoss implementation instead of the one of GlassFish, as it works as well and is easier to configure.
           -->
         <dependency>
-          <groupId>javax.servlet</groupId>
-          <artifactId>javax.servlet-api</artifactId>
+          <groupId>org.jboss.spec.javax.servlet</groupId>
+          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
           <scope>provided</scope>
-          <version>${version.glassfish40_servlet_api}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -147,6 +147,14 @@
           <version>${version.wildfly.arquillian.container}</version>
           <scope>test</scope>
         </dependency>
+        <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
+            test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
+         -->
+        <dependency>
+          <groupId>org.jboss.spec.javax.servlet</groupId>
+          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+          <scope>provided</scope>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -158,14 +166,17 @@
           <version>${version.wildfly.arquillian.container}</version>
           <scope>test</scope>
         </dependency>
+        <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
+            test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
+         -->
+        <dependency>
+          <groupId>org.jboss.spec.javax.servlet</groupId>
+          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+          <scope>provided</scope>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
-      <!--
-        Note: to run this profile, an additional change has to be made in "extension/jsf-ftest/pom.xml".
-        Otherwise, the test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" will fail.
-        See explanation there.
-      -->
       <id>tomee-managed</id>
       <activation>
         <property>
@@ -187,6 +198,15 @@
           <artifactId>arquillian-tomee-remote</artifactId>
           <version>${version.tomee}</version>
           <scope>test</scope>
+        </dependency>
+        <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
+            test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
+         -->
+        <dependency>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-servlet-api</artifactId>
+          <scope>provided</scope>
+          <version>${version.tomee}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -211,6 +231,15 @@
           <version>${version.arquillian.glassfish40}</version>
           <scope>test</scope>
         </dependency>
+        <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
+            test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
+         -->
+        <dependency>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+          <scope>provided</scope>
+          <version>${version.glassfish40_servlet_api}</version>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -230,6 +259,15 @@
           <artifactId>arquillian-glassfish-remote-3.1</artifactId>
           <version>${version.arquillian.glassfish40}</version>
           <scope>test</scope>
+        </dependency>
+        <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
+            test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
+         -->
+        <dependency>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+          <scope>provided</scope>
+          <version>${version.glassfish40_servlet_api}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -149,7 +149,7 @@
         </dependency>
         <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
             test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
-         -->
+          -->
         <dependency>
           <groupId>org.jboss.spec.javax.servlet</groupId>
           <artifactId>jboss-servlet-api_3.0_spec</artifactId>
@@ -168,7 +168,7 @@
         </dependency>
         <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
             test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
-         -->
+          -->
         <dependency>
           <groupId>org.jboss.spec.javax.servlet</groupId>
           <artifactId>jboss-servlet-api_3.0_spec</artifactId>
@@ -201,7 +201,7 @@
         </dependency>
         <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
             test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
-         -->
+          -->
         <dependency>
           <groupId>org.apache.tomcat</groupId>
           <artifactId>tomcat-servlet-api</artifactId>
@@ -233,7 +233,8 @@
         </dependency>
         <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
             test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
-         -->
+            Here we could also use the JBoss implementation.
+          -->
         <dependency>
           <groupId>javax.servlet</groupId>
           <artifactId>javax.servlet-api</artifactId>
@@ -262,7 +263,7 @@
         </dependency>
         <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
             test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
-         -->
+          -->
         <dependency>
           <groupId>javax.servlet</groupId>
           <artifactId>javax.servlet-api</artifactId>

--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -24,7 +24,7 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
-	<!--The dependency on the servlet api must be declared for each profile contained "ftest-base/pom.xml" instead of using "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec",
+    <!--The dependency on the servlet api must be declared for each profile contained "ftest-base/pom.xml" instead of using "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec",
         as the test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" would fail for TomEE (see detailed explanation in this test)
       -->
     <dependency>

--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -24,28 +24,9 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!--
-        The test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" (see detailed explanation there)
-        will fail in profile "tomee-managed" with this error:
-
-        javax.servlet.ServletException : null [Proxied because : Original exception caused: class java.io.InvalidClassException: javax.servlet.ServletException;
-        local class incompatible: stream classdesc serialVersionUID = 1, local class serialVersionUID = 4221302886851315160]
-
-        Workaround: replace the dependency on the servlet spec from JBoss with a dependency on "org.apache.tomcat:tomcat-servlet-api".
+	<!--The dependency on the servlet api must be declared for each profile contained "ftest-base/pom.xml" instead of using "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec",
+        as the test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" would fail for TomEE (see detailed explanation in this test)
       -->
-    <dependency>
-      <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <!--
-    <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>tomcat-servlet-api</artifactId>
-      <scope>provided</scope>
-      <version>${version.tomee}</version>
-    </dependency>
-    -->
     <dependency>
       <groupId>org.jboss.spec.javax.faces</groupId>
       <artifactId>jboss-jsf-api_2.1_spec</artifactId>

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestFacesLifecycleFailurePropagation.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestFacesLifecycleFailurePropagation.java
@@ -84,32 +84,18 @@ import org.openqa.selenium.WebDriver;
 public class TestFacesLifecycleFailurePropagation {
 
     /**
-     * This test will fail in the profile "tomee-managed" with this error:
+     * This test is the reason for the fact that the dependency on the servlet API jar is declared for each profile/container
+     * in "ftest-base/pom.xml" instead of declaring a global dependency on "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec".
+     * If using a global dependency on the JBoss jar, the "tomee-managed" profile will fail with this error:
      *
      * javax.servlet.ServletException : null [Proxied because : Original exception caused: class java.io.InvalidClassException: javax.servlet.ServletException;
      * local class incompatible: stream classdesc serialVersionUID = 1, local class serialVersionUID = 4221302886851315160]
      *
-     * Reason (see https://github.com/arquillian/arquillian-extension-warp/pull/108#issuecomment-1475388798):
-     * extension/jsf-ftest/pom.xml declares a dependency "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec", where
-     * no serialVersionUID is defined on "ServletException".
-     * The TomEE implementation of "ServletException" from org.apache.tomcat:tomcat-servlet-api defines a serialVersionUID = 1.
+     * Reason: the dependency "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec" does not define a serialVersionUID on "ServletException".
+     * The TomEE implementation of "ServletException" from "org.apache.tomcat:tomcat-servlet-api" defines a serialVersionUID = 1.
      * This causes the error.
+     * So the dependency must be declared for each profile.
      *
-     * Workaround: replace this in extension/jsf-ftest/pom.xml
-     *     <dependency>
-     *       <groupId>org.jboss.spec.javax.servlet</groupId>
-     *       <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-     *       <scope>provided</scope>
-     *     </dependency>
-     *
-     * with this:
-     *
-     *     <dependency>
-     *       <groupId>org.apache.tomcat</groupId>
-     *       <artifactId>tomcat-servlet-api</artifactId>
-     *       <scope>provided</scope>
-     *       <version>${version.tomee}</version>
-     *     </dependency>
      */
 
     @Drone

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -12,7 +12,7 @@
   <name>Arquillian Warp: Functional Test</name>
 
   <dependencies>
-	<!--The dependency on the servlet api must be declared for each profile contained "ftest-base/pom.xml" instead of using "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec",
+    <!--The dependency on the servlet api must be declared for each profile contained "ftest-base/pom.xml" instead of using "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec",
         as the test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" would fail for TomEE (see detailed explanation in this test)
       -->
     <dependency>

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -12,10 +12,9 @@
   <name>Arquillian Warp: Functional Test</name>
 
   <dependencies>
-    <dependency>
-      <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-    </dependency>
+	<!--The dependency on the servlet api must be declared for each profile contained "ftest-base/pom.xml" instead of using "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec",
+        as the test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" would fail for TomEE (see detailed explanation in this test)
+      -->
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,8 @@
     <!-- Container Versions -->
     <version.tomee>8.0.14</version.tomee>
     <version.glassfish40>4.0</version.glassfish40>
+    <!--This is the version of the file "javax.servlet-api.jar" found in "glassfish4/glassfish/modules" corresponding to the glassfish version-->
+    <version.glassfish40_servlet_api>3.1.0</version.glassfish40_servlet_api>
     <version.tomcat6>6.0.35</version.tomcat6>
     <version.tomcat7>7.0.26</version.tomcat7>
     <version.wildfly>26.1.3.Final</version.wildfly>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,6 @@
     <!-- Container Versions -->
     <version.tomee>8.0.14</version.tomee>
     <version.glassfish40>4.0</version.glassfish40>
-    <!--This is the version of the file "javax.servlet-api.jar" found in "glassfish4/glassfish/modules" corresponding to the glassfish version-->
-    <version.glassfish40_servlet_api>3.1.0</version.glassfish40_servlet_api>
     <version.tomcat6>6.0.35</version.tomcat6>
     <version.tomcat7>7.0.26</version.tomcat7>
     <version.wildfly>26.1.3.Final</version.wildfly>


### PR DESCRIPTION
While researching something completely different, I finally found a resolution for the TomEE error in [#108](https://github.com/arquillian/arquillian-extension-warp/pull/108#issuecomment-1475388798) (TomEE servlet api implementation declares a different serialVersionUID for "ServletException" than the JBoss implementation does, and one test fails because of this conflict).

The fix sounds quite reasonable to me: instead of declaring a global dependency on "org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec" in the two testing projects "ftest/pom.xml" and "jsf-ftest/pom.xml", I declare a dependency on the servlet api jar for each profile in "ftest-base/pom.xml", matching the server implementation. It is not perfect for WildFly, as WildFly 26 actually provides "org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec:2.0.0.Final".

Somehow, even Eclipse allows to use e.g. "javax.servlet.ServletException" in test classes of the "jsf-ftest" project, though this is not used in the current code. I hope it is pulled from the default profile. This is the only place where I feel a bit unsecure about this change.

With this change, the profiles "wildfly-managed", "tomee-managed" and "glassfish-managed-4-0" all work without further modifcations. Would it be possible to add all three to "build.yml"?