### PR TITLE
Fix maven-license-plugin warning about deprecated properties

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -168,28 +168,32 @@
                     <version>4.2</version>
                     <configuration>
                         <basedir>${basedir}</basedir>
-                        <header>licences/warp-license-header.txt</header>
                         <quiet>false</quiet>
                         <failIfMissing>true</failIfMissing>
                         <strictCheck>true</strictCheck>
                         <aggregate>false</aggregate>
-                        <includes>
-                            <include>src/**</include>
-                            <include>**/test/**</include>
-                        </includes>
-                        <excludes>
-                            <exclude>.gitignore</exclude>
-                        </excludes>
                         <properties>
                             <year>^\d{4}$</year>
                         </properties>
-                        <validHeaders>
-                            <validHeader>licences/apache-commons-codec.txt</validHeader>
-                        </validHeaders>
                         <skipExistingHeaders>true</skipExistingHeaders>
                         <mapping>
-                          <java>SLASHSTAR_STYLE</java>
+                            <java>SLASHSTAR_STYLE</java>
                         </mapping>
+                        <licenseSets>
+                            <licenseSet>
+                                <header>licences/warp-license-header.txt</header>
+                                <includes>
+                                    <include>src/**</include>
+                                    <include>**/test/**</include>
+                                </includes>
+                                <excludes>
+                                    <exclude>.gitignore</exclude>
+                                </excludes>
+                                <validHeaders>
+                                    <validHeader>licences/apache-commons-codec.txt</validHeader>
+                                </validHeaders>
+                            </licenseSet>
+                        </licenseSets>
                     </configuration>
                     <executions>
                         <execution>

--- a/build/resources/pom.xml
+++ b/build/resources/pom.xml
@@ -42,12 +42,16 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>src/main/resources/licences/apache-commons-codec.txt</exclude>
-            <exclude>src/main/resources/licences/warp-license-header.txt</exclude>
-            <exclude>src/main/resources/licences/warp-license-header-2012.txt</exclude>
-            <exclude>src/main/resources/code-style/checkstyle.xml</exclude>
-          </excludes>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <exclude>src/main/resources/licences/apache-commons-codec.txt</exclude>
+                <exclude>src/main/resources/licences/warp-license-header.txt</exclude>
+                <exclude>src/main/resources/licences/warp-license-header-2012.txt</exclude>
+                <exclude>src/main/resources/code-style/checkstyle.xml</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
 
       </plugin>

--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -144,9 +144,13 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>**/*.properties</exclude>
-          </excludes>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <exclude>**/*.properties</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
       </plugin>
       <plugin>

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -119,9 +119,13 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>**/*.properties</exclude>
-          </excludes>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <exclude>**/*.properties</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
       </plugin>
       <plugin>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -127,11 +127,15 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>src/main/resources/log4j.properties</exclude>
-            <exclude>src/main/java/org/jboss/arquillian/warp/impl/utils/Platform.java</exclude>
-            <exclude>src/main/java/org/jboss/arquillian/warp/impl/utils/net/*.java</exclude>
-          </excludes>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <exclude>src/main/resources/log4j.properties</exclude>
+                <exclude>src/main/java/org/jboss/arquillian/warp/impl/utils/Platform.java</exclude>
+                <exclude>src/main/java/org/jboss/arquillian/warp/impl/utils/net/*.java</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
The update to license-maven-plugin 4.2 by pull request #111 caused several warnings like this:

```
[INFO] --- license:4.2:check (license-check) @ arquillian-warp-jsf-ftest ---
[WARNING] Parameter 'legacyConfigExcludes' (user property 'license.excludes') is deprecated: use LicenseSet.excludes
[WARNING] Parameter 'legacyConfigHeader' (user property 'license.header') is deprecated: use LicenseSet.header
[WARNING] Parameter 'legacyConfigIncludes' (user property 'license.includes') is deprecated: use LicenseSet.includes
[WARNING] Parameter 'legacyConfigValidHeaders' is deprecated: use LicenseSet.validHeaders
[INFO] Checking licenses...
```

The resolution seems to be to encapsulate those config options in a "licenseSet" element. This is the snippet from "build\pom.xml" (which contains the root config, other projects just extend it)

```
                <plugin>
                    <groupId>com.mycila</groupId>
                    <artifactId>license-maven-plugin</artifactId>
                    <version>4.2</version>
                    <configuration>
                        <basedir>${basedir}</basedir>
                        <quiet>false</quiet>
                        <failIfMissing>true</failIfMissing>
                        <strictCheck>true</strictCheck>
                        <aggregate>false</aggregate>
                        <properties>
                            <year>^\d{4}$</year>
                        </properties>
                        <skipExistingHeaders>true</skipExistingHeaders>
                        <mapping>
                            <java>SLASHSTAR_STYLE</java>
                        </mapping>
                        <licenseSets>
                            <licenseSet>
                                <header>licences/warp-license-header.txt</header>
                                <includes>
                                    <include>src/**</include>
                                    <include>**/test/**</include>
                                </includes>
                                <excludes>
                                    <exclude>.gitignore</exclude>
                                </excludes>
                                <validHeaders>
                                    <validHeader>licences/apache-commons-codec.txt</validHeader>
                                </validHeaders>
                            </licenseSet>
                        </licenseSets>
                    </configuration>

```

See here: https://mycila.carbou.me/license-maven-plugin/#plugin-declaration