### PR TITLE
Remove tomcat profiles and unused configuration parameters

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -21,8 +21,6 @@
     <arquillian.debug>false</arquillian.debug>
     <arquillian.drone.browser>htmlUnit</arquillian.drone.browser>
     <arquillian.drone.reusable>false</arquillian.drone.reusable>
-    <arquillian.richfaces.servletContainerSetup>false</arquillian.richfaces.servletContainerSetup>
-    <arquillian.richfaces.jsfImplementation>org.glassfish:javax.faces</arquillian.richfaces.jsfImplementation>
     <arquillian.container.home />
     <arquillian.container.distribution />
     <arquillian.container.configuration />
@@ -186,7 +184,6 @@
       </activation>
       <properties>
         <arquillian.launch.tomee>true</arquillian.launch.tomee>
-        <arquillian.richfaces.jsfProvider>myfaces</arquillian.richfaces.jsfProvider>
         <arquillian.container.home>${project.build.directory}/apache-tomee-webprofile-${version.tomee}
         </arquillian.container.home>
         <arquillian.container.distribution>org.apache.tomee:apache-tomee:zip:webprofile:${version.tomee}
@@ -268,84 +265,6 @@
           <groupId>org.jboss.spec.javax.servlet</groupId>
           <artifactId>jboss-servlet-api_3.0_spec</artifactId>
           <scope>provided</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>tomcat-remote-6</id>
-      <activation>
-        <property>
-          <name>integration</name>
-          <value>tomcat6-remote</value>
-        </property>
-      </activation>
-      <properties>
-        <arquillian.launch.tomcat6>true</arquillian.launch.tomcat6>
-        <arquillian.richfaces.servletContainerSetup>true</arquillian.richfaces.servletContainerSetup>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.jboss.arquillian.container</groupId>
-          <artifactId>arquillian-tomcat-remote-6</artifactId>
-          <version>1.1.0.Final</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>tomcat-managed-6</id>
-      <activation>
-        <property>
-          <name>integration</name>
-          <value>tomcat6</value>
-        </property>
-      </activation>
-      <properties>
-        <arquillian.launch.tomcat6>true</arquillian.launch.tomcat6>
-        <arquillian.richfaces.servletContainerSetup>true</arquillian.richfaces.servletContainerSetup>
-        <arquillian.container.home>${project.build.directory}/apache-tomcat-${version.tomcat6}
-        </arquillian.container.home>
-        <arquillian.container.distribution>com.googlecode.t7mp:tomcat:zip:${version.tomcat6}
-        </arquillian.container.distribution>
-        <arquillian.container.configuration>
-          org.richfaces:richfaces-build-resources:zip:configuration-tomcat:${version.richfaces}
-        </arquillian.container.configuration>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.jboss.arquillian.container</groupId>
-          <artifactId>arquillian-tomcat-managed-6</artifactId>
-          <version>1.1.0.Final</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>tomcat-managed-7</id>
-      <activation>
-        <property>
-          <name>integration</name>
-          <value>tomcat7</value>
-        </property>
-      </activation>
-      <properties>
-        <catalinaHome>${project.build.directory}/apache-tomcat-${version.tomcat7}</catalinaHome>
-        <arquillian.launch.tomcat7>true</arquillian.launch.tomcat7>
-        <arquillian.richfaces.servletContainerSetup>true</arquillian.richfaces.servletContainerSetup>
-        <arquillian.container.home>${project.build.directory}/apache-tomcat-${version.tomcat7}
-        </arquillian.container.home>
-        <arquillian.container.distribution>com.googlecode.t7mp:tomcat:zip:${version.tomcat7}
-        </arquillian.container.distribution>
-        <arquillian.container.configuration>
-          org.richfaces:richfaces-build-resources:zip:configuration-tomcat:${version.richfaces}
-        </arquillian.container.configuration>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.jboss.arquillian.container</groupId>
-          <artifactId>arquillian-tomcat-managed-7</artifactId>
-          <version>1.1.0.Final</version>
-          <scope>test</scope>
         </dependency>
       </dependencies>
     </profile>

--- a/build/resources/src/main/java/org/arquillian/warp/ftest/configuration/IntegrationTestConfiguration.java
+++ b/build/resources/src/main/java/org/arquillian/warp/ftest/configuration/IntegrationTestConfiguration.java
@@ -24,8 +24,6 @@ import org.jboss.arquillian.drone.spi.DroneConfiguration;
 
 public class IntegrationTestConfiguration implements DroneConfiguration<IntegrationTestConfiguration> {
 
-    private Boolean servletContainerSetup;
-    private String jsfImplementation;
     private String containerHome;
     private String containerDistribution;
     private String containerConfiguration;
@@ -33,20 +31,6 @@ public class IntegrationTestConfiguration implements DroneConfiguration<Integrat
     private Boolean debug;
 
     private boolean containerInstalledFromDistribution = false;
-
-    /**
-     * Add JSF to the WebArchive for support of plain Servlet containers (Tomcat, Jetty, etc.)
-     */
-    public boolean servletContainerSetup() {
-        return servletContainerSetup;
-    }
-
-    /**
-     * Get the Maven dependency (GAV) for the JSF implementation used for testing in servlet containers
-     */
-    public String getJsfImplementation() {
-        return jsfImplementation;
-    }
 
     /**
      * Get the Maven dependency (GAV) for the container distribution artifact
@@ -85,15 +69,6 @@ public class IntegrationTestConfiguration implements DroneConfiguration<Integrat
 
     public boolean isDebug() {
         return debug != null && debug;
-    }
-
-    /**
-     * Validates the configuration
-     */
-    public void validate() {
-        if (servletContainerSetup == null) {
-            throw new IllegalArgumentException("The servletContainerSetup configuration needs to be specified");
-        }
     }
 
     /*

--- a/build/resources/src/main/java/org/arquillian/warp/ftest/configuration/IntegrationTestConfiguratorObserver.java
+++ b/build/resources/src/main/java/org/arquillian/warp/ftest/configuration/IntegrationTestConfiguratorObserver.java
@@ -31,7 +31,7 @@ public class IntegrationTestConfiguratorObserver {
 
     public void configure(@Observes ArquillianDescriptor descriptor) {
         IntegrationTestConfiguration c = new IntegrationTestConfiguration();
-        c.configure(descriptor, Default.class).validate();
+        c.configure(descriptor, Default.class);
         configuration.set(c);
     }
 }

--- a/build/resources/src/main/resources/arquillian.xml
+++ b/build/resources/src/main/resources/arquillian.xml
@@ -88,10 +88,6 @@
   </extension>
 
   <extension qualifier="suite">
-    <!-- true if the JSF should be added to the WebArchive for support of plain Servlet containers (Tomcat, Jetty, etc.) -->
-    <property name="servletContainerSetup">${arquillian.richfaces.servletContainerSetup}</property>
-    <!-- GAV of the JSF implementation used for testing in servlet containers -->
-    <property name="jsfImplementation">${arquillian.richfaces.jsfImplementation}</property>
     <!-- the home of the container -->
     <property name="containerHome">${arquillian.container.home}</property>
     <!-- the GAV of container distribution artifact -->


### PR DESCRIPTION
The tomcat profiles do not work currently and are not fixable, see #86

This pull request also removes two unused configuration parameters, see discussion in issue #86.