### PR TITLE
Updates Glassfish from 4.0 to 5.1, renamed profiles

### DIFF
--- a/.github/workflows/glassfish-managed.yml
+++ b/.github/workflows/glassfish-managed.yml
@@ -30,7 +30,7 @@ jobs:
         java-version: ${{ matrix.jdk-version }}
         cache: maven
     - name: Run Tests
-      run: mvn -ntp -U -B -Pglassfish-managed-4-0 clean verify
+      run: mvn -ntp -U -B -Pglassfish-managed clean verify
     - uses: actions/upload-artifact@v3
       if: failure()
       with:

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.shrinkwrap.descriptors>2.0.0</version.shrinkwrap.descriptors>
-    <version.arquillian.glassfish40>1.0.2</version.arquillian.glassfish40>
+    <version.arquillian.glassfish>1.0.2</version.arquillian.glassfish>
 
     <!-- Arquillian Configuration -->
     <arquillian.debug>false</arquillian.debug>
@@ -34,7 +34,7 @@
     <arquillian.launch.tomcat6>false</arquillian.launch.tomcat6>
     <arquillian.launch.tomcat7>false</arquillian.launch.tomcat7>
     <arquillian.launch.tomee>false</arquillian.launch.tomee>
-    <arquillian.launch.glassfish40>false</arquillian.launch.glassfish40>
+    <arquillian.launch.glassfish>false</arquillian.launch.glassfish>
   </properties>
 
   <dependencyManagement>
@@ -208,24 +208,28 @@
       </dependencies>
     </profile>
     <profile>
-      <id>glassfish-managed-4-0</id>
+      <!-- Don't run this profile on windows: the test performance will be incredibly poor (90 seconds per test).
+           It works fast on linux.
+           See https://github.com/arquillian/arquillian-extension-warp/issues/131
+      -->
+      <id>glassfish-managed</id>
       <activation>
         <property>
           <name>integration</name>
-          <value>glassfish40</value>
+          <value>glassfish</value>
         </property>
       </activation>
       <properties>
-        <arquillian.launch.glassfish40>true</arquillian.launch.glassfish40>
-        <arquillian.container.home>${project.build.directory}/glassfish4</arquillian.container.home>
-        <arquillian.container.distribution>org.glassfish.main.distributions:glassfish:zip:${version.glassfish40}
+        <arquillian.launch.glassfish>true</arquillian.launch.glassfish>
+        <arquillian.container.home>${project.build.directory}/glassfish5</arquillian.container.home>
+        <arquillian.container.distribution>org.glassfish.main.distributions:glassfish:zip:${version.glassfish}
         </arquillian.container.distribution>
       </properties>
       <dependencies>
         <dependency>
           <groupId>org.jboss.arquillian.container</groupId>
           <artifactId>arquillian-glassfish-managed-3.1</artifactId>
-          <version>${version.arquillian.glassfish40}</version>
+          <version>${version.arquillian.glassfish}</version>
           <scope>test</scope>
         </dependency>
         <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
@@ -240,21 +244,31 @@
       </dependencies>
     </profile>
     <profile>
-      <id>glassfish-remote-4-0</id>
+      <!-- Don't run this profile on windows: the test performance will be incredibly poor (90 seconds per test).
+           It works fast on linux.
+           See https://github.com/arquillian/arquillian-extension-warp/issues/131
+      
+           A guide to run it: start GlassFish with this command (remove the "[x]" text - it is just a separator, because double hyphen is forbidden)
+           asadmin start-domain -[x]-verbose=true
+           
+           Shut it down after the tests with this command:
+           asadmin stop-domain domain1
+      -->
+      <id>glassfish-remote</id>
       <activation>
         <property>
           <name>integration</name>
-          <value>glassfish40-remote</value>
+          <value>glassfish-remote</value>
         </property>
       </activation>
       <properties>
-        <arquillian.launch.glassfish40>true</arquillian.launch.glassfish40>
+        <arquillian.launch.glassfish>true</arquillian.launch.glassfish>
       </properties>
       <dependencies>
         <dependency>
           <groupId>org.jboss.arquillian.container</groupId>
           <artifactId>arquillian-glassfish-remote-3.1</artifactId>
-          <version>${version.arquillian.glassfish40}</version>
+          <version>${version.arquillian.glassfish}</version>
           <scope>test</scope>
         </dependency>
         <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the

--- a/build/resources/src/main/resources/arquillian.xml
+++ b/build/resources/src/main/resources/arquillian.xml
@@ -69,7 +69,7 @@
     </configuration>
   </container>
 
-  <container qualifier="glassfish40" default="${arquillian.launch.glassfish40}">
+  <container qualifier="glassfish" default="${arquillian.launch.glassfish}">
     <configuration>
       <property name="glassFishHome">${arquillian.container.home}</property>
       <property name="javaVmArguments">${arquillian.container.vmargs}</property>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
     <!-- Container Versions -->
     <version.tomee>8.0.14</version.tomee>
-    <version.glassfish40>4.0</version.glassfish40>
+    <version.glassfish>5.1.0</version.glassfish>
     <version.tomcat6>6.0.35</version.tomcat6>
     <version.tomcat7>7.0.26</version.tomcat7>
     <version.wildfly>26.1.3.Final</version.wildfly>


### PR DESCRIPTION
See issue #131

The GlassFish profiles will run with horrible performance on Windows, but they are fast as before in Linux, see discussion in issue. The windows problem is something that can be taken care of in future versions, e.g. when updating to JakartaEE10 and recent GlassFish versions.

Hopefully, the renaming of the "glassfish-managed" profile will not break the automated test from "glassfish-managed.yml".