### PR TITLE
Repair drone webdriver for firefox and chrome, cleanup

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -282,6 +282,7 @@
     </profile>
 
     <profile>
+      <!--While executing the tests, Drone uses a locally installed Chrome browser. Combine this profile with any server profile, e.g. "mvnw clean install -Pwildfly-remote,browser-chrome"-->
       <id>browser-chrome</id>
       <activation>
         <property>
@@ -295,6 +296,7 @@
     </profile>
 
     <profile>
+      <!--While executing the tests, Drone uses a locally installed Firefox browser. Combine this profile with any server profile, e.g. "mvnw clean install -Pwildfly-remote,browser-firefox"-->
       <id>browser-firefox</id>
       <activation>
         <property>

--- a/build/resources/src/main/resources/arquillian.xml
+++ b/build/resources/src/main/resources/arquillian.xml
@@ -54,18 +54,9 @@
 
   <extension qualifier="webdriver">
     <property name="browser">${arquillian.drone.browser}</property>
-    <!--Workaround for errors in Drone 3.0.0.Alpha7 - see https://github.com/arquillian/arquillian-extension-drone/issues/418-->
-    <property name="browserVersion">*</property>
 
     <property name="remoteReusable">${arquillian.drone.reusable}</property>
     <property name="remoteAddress">http://localhost:4444/wd/hub/</property>
-
-    <!--With Drone 3.0.0.Alpha7 and Chrome 115 or newer, the automatic download of "chromedriver" fails,
-	    see https://chromedriver.chromium.org/downloads/version-selection
-	    You have to download it and set this property to the path.
-    <property name="chromeDriverBinary">/opt/google/chrome/chromedriver</property>
-    -->
-
   </extension>
 
   <extension qualifier="suite">

--- a/build/resources/src/main/resources/arquillian.xml
+++ b/build/resources/src/main/resources/arquillian.xml
@@ -54,12 +54,17 @@
 
   <extension qualifier="webdriver">
     <property name="browser">${arquillian.drone.browser}</property>
+    <!--Workaround for errors in Drone 3.0.0.Alpha7 - see https://github.com/arquillian/arquillian-extension-drone/issues/418-->
+    <property name="browserVersion">*</property>
+
     <property name="remoteReusable">${arquillian.drone.reusable}</property>
     <property name="remoteAddress">http://localhost:4444/wd/hub/</property>
 
-    <property name="javascriptEnabled">true</property>
+    <!--With Drone 3.0.0.Alpha7 and Chrome 115 or newer, the automatic download of "chromedriver" fails,
+	    see https://chromedriver.chromium.org/downloads/version-selection
+	    You have to download it and set this property to the path.
     <property name="chromeDriverBinary">/opt/google/chrome/chromedriver</property>
-    <property name="phantomjs.binary.path">target/phantomjs</property>
+    -->
 
   </extension>
 


### PR DESCRIPTION
The profiles "browser-firefox" and "browser-chrome" don't work since the update to Drone 3.0.0.Alpha7 (#91).

To run them, you have to combine the profile with a server profile:
`mvn clean install -Pwildfly-remote,browser-firefox`

The error for firefox is:
```
java.lang.RuntimeException: 
Unable to instantiate Drone via org.openqa.selenium.firefox.FirefoxDriver(FirefoxOptions): org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: Unable to find a matching set of capabilities
Build info: version: '4.3.0', revision: 'a4995e2c09*'
System info: host: 'MYCOMPUTER', ip: '192.168.178.101', os.name: 'Windows 10', os.arch: 'amd64', os.version: '10.0', java.version: '17.0.8'
Driver info: org.openqa.selenium.firefox.FirefoxDriver
Command: [null, newSession {capabilities=[Capabilities {acceptInsecureCerts: true, browserName: firefox, browserVersion: , moz:debuggerAddress: true, moz:firefoxOptions: {}}], desiredCapabilities=Capabilities {acceptInsecureCerts: true, browserName: firefox, browserVersion: , moz:debuggerAddress: true, moz:firefoxOptions: {}, platformName: ANY}}]
Caused by: org.openqa.selenium.SessionNotCreatedException: 
Could not start a new session. Response code 500. Message: Unable to find a matching set of capabilities
Build info: version: '4.3.0', revision: 'a4995e2c09*'
System info: host: 'MYCOMPUTER', ip: '192.168.178.101', os.name: 'Windows 10', os.arch: 'amd64', os.version: '10.0', java.version: '17.0.8'
Driver info: org.openqa.selenium.firefox.FirefoxDriver
Command: [null, newSession {capabilities=[Capabilities {acceptInsecureCerts: true, browserName: firefox, browserVersion: , moz:debuggerAddress: true, moz:firefoxOptions: {}}], desiredCapabilities=Capabilities {acceptInsecureCerts: true, browserName: firefox, browserVersion: , moz:debuggerAddress: true, moz:firefoxOptions: {}, platformName: ANY}}]
```

And the error for chrome:
```
Unable to instantiate Drone via org.openqa.selenium.chrome.ChromeDriver(ChromeOptions): org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 400. Message: invalid argument: entry 0 of 'firstMatch' is invalid
from invalid argument: cannot parse capability: browserVersion
from invalid argument: cannot be empty
Build info: version: '4.3.0', revision: 'a4995e2c09*'
System info: host: 'MYCOMPUTER', ip: '192.168.178.101', os.name: 'Windows 10', os.arch: 'amd64', os.version: '10.0', java.version: '1.8.0_381'
Driver info: org.openqa.selenium.chrome.ChromeDriver
Command: [null, newSession {capabilities=[Capabilities {browserName: chrome, browserVersion: , goog:chromeOptions: {args: [], extensions: []}}], desiredCapabilities=Capabilities {browserName: chrome, browserVersion: , goog:chromeOptions: {args: [], extensions: []}, platformName: ANY}}]
        at org.jboss.arquillian.drone.webdriver.factory.SecurityActions.newInstance(SecurityActions.java:166)
        at org.jboss.arquillian.drone.webdriver.factory.ChromeDriverFactory.createInstance(ChromeDriverFactory.java:81)
        at org.jboss.arquillian.drone.webdriver.factory.ChromeDriverFactory.createInstance(ChromeDriverFactory.java:42)
        at org.jboss.arquillian.drone.webdriver.factory.WebDriverFactory.createInstance(WebDriverFactory.java:127)
        at org.jboss.arquillian.drone.webdriver.factory.WebDriverFactory.createInstance(WebDriverFactory.java:38)
        at org.jboss.arquillian.drone.impl.DroneConfigurator$1.createInstance(DroneConfigurator.java:112)
        at org.jboss.arquillian.drone.impl.CachingCallableImpl.call(CachingCallableImpl.java:44)
        at org.jboss.arquillian.core.impl.threading.ThreadedExecutorService$ContextualCallable.call(ThreadedExecutorService.java:88)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
```

Workaround/resolution: add a "browserVersion" property. Here, a wildcard works.
```
<extension qualifier="webdriver">
    <property name="browser">${arquillian.drone.browser}</property>
    <property name="browserVersion">*</property>
</extension>
```
I asked in the drone github: https://github.com/arquillian/arquillian-extension-drone/issues/418 whether this is a regression or an intentional change 

I also removed the property `phantomjs.binary.path`, as there is a drone pull request to remove support for it: https://github.com/arquillian/arquillian-extension-drone/pull/403

And I commented `chromeDriverBinary`. The test will fail if the chromedriver is not placed in this directory, and it causes a warning when executing the tests:
`WARNUNG: Support for Legacy Capabilities is deprecated; You are sending the following invalid capabilities: [chromeDriverBinary, javascriptEnabled, phantomjs.binary.path]; Please update to W3C Syntax: https://www.selenium.dev/blog/2022/legacy-protocol-support/`

But `chromeDriverBinary` might still be necessary, as the chrome profile will not work with recent version 117. The downloaded chromedriver does not support 117:
```
Unable to instantiate Drone via org.openqa.selenium.chrome.ChromeDriver(ChromeOptions): org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: session not created: This version of ChromeDriver only supports Chrome version 114
Current browser version is 117.0.5938.132 with binary path C:\Program Files\Google\Chrome\Application\chrome.exe
Build info: version: '4.3.0', revision: 'a4995e2c09*'
System info: host: 'MYCOMPUTER', ip: '192.168.178.101', os.name: 'Windows 10', os.arch: 'amd64', os.version: '10.0', java.version: '1.8.0_381'
Driver info: org.openqa.selenium.chrome.ChromeDriver
Command: [null, newSession {capabilities=[Capabilities {browserName: chrome, browserVersion: *, goog:chromeOptions: {args: [], extensions: []}}], desiredCapabilities=Capabilities {browserName: chrome, browserVersion: *, goog:chromeOptions: {args: [], extensions: []}, platformName: ANY}}]
        at org.jboss.arquillian.drone.webdriver.factory.SecurityActions.newInstance(SecurityActions.java:166)
        at org.jboss.arquillian.drone.webdriver.factory.ChromeDriverFactory.createInstance(ChromeDriverFactory.java:81)
        at org.jboss.arquillian.drone.webdriver.factory.ChromeDriverFactory.createInstance(ChromeDriverFactory.java:42)
        at org.jboss.arquillian.drone.webdriver.factory.WebDriverFactory.createInstance(WebDriverFactory.java:127)
        at org.jboss.arquillian.drone.webdriver.factory.WebDriverFactory.createInstance(WebDriverFactory.java:38)
        at org.jboss.arquillian.drone.impl.DroneConfigurator$1.createInstance(DroneConfigurator.java:112)
        at org.jboss.arquillian.drone.impl.CachingCallableImpl.call(CachingCallableImpl.java:44)
        at org.jboss.arquillian.core.impl.threading.ThreadedExecutorService$ContextualCallable.call(ThreadedExecutorService.java:88)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
```

It seems this is caused by the fact that the download for chromedriver has changed since 115: https://chromedriver.chromium.org/downloads/version-selection
This probably requires an update to latest Selenium, which has be done through Drone. There is also a Drone pull request for this: https://github.com/arquillian/arquillian-extension-drone/pull/401

When downloading a matching chromedriver and setting the property "chromeDriver"...
`<property name="chromeDriverBinary">c:\path\to\chromedriver.exe</property>`
...it still fails:

```
Sep 29, 2023 9:18:03 PM org.openqa.selenium.remote.http.WebSocket$Listener onError
WARNUNG: Invalid Status code=403 text=Forbidden
java.io.IOException: Invalid Status code=403 text=Forbidden
        at org.asynchttpclient.netty.handler.WebSocketHandler.abort(WebSocketHandler.java:92)
        at org.asynchttpclient.netty.handler.WebSocketHandler.handleRead(WebSocketHandler.java:118)
        at org.asynchttpclient.netty.handler.AsyncHttpClientHandler.channelRead(AsyncHttpClientHandler.java:78)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:314)
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:435)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
        at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:750)

```


And this is the point where I give up for now ;-). 
Those pages https://stackoverflow.com/questions/75730109/how-to-overcome-invalid-status-code-403-text-forbidden-this-error-in-selenium and https://github.com/SeleniumHQ/selenium/issues/11750 suggest to use a chrome argument `--remote-allow-origins=*`, but I could not make it work with Drone. This did not work:
`	<property name="chromeArguments">--remote-allow-origins=*</property>`

If Drone supports latest Selenium, it would be worth another look.