### PR TITLE
Fixed warnings about generics

### DIFF
--- a/extension/jsf/src/main/java/org/jboss/arquillian/warp/jsf/enricher/SecurityActions.java
+++ b/extension/jsf/src/main/java/org/jboss/arquillian/warp/jsf/enricher/SecurityActions.java
@@ -315,6 +315,7 @@ final class SecurityActions {
 
     }
 
+    @SuppressWarnings("unchecked")
     static <T extends Annotation> T findAnnotation(final Annotation[] annotations, final Class<T> needle) {
         for (Annotation a : annotations) {
             if (a.annotationType() == needle) {

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/DefaultWarpRequestSpecifier.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/DefaultWarpRequestSpecifier.java
@@ -69,12 +69,11 @@ public class DefaultWarpRequestSpecifier implements WarpRequestSpecifier {
      * (non-Javadoc)
      * @see org.jboss.arquillian.warp.client.execution.SingleVerificationSpecifier#verify(org.jboss.arquillian.warp.ServerInspection)
      */
-    @SuppressWarnings("unchecked")
     public <T extends Inspection> T inspect(T inspection) {
         initializeSingleGroup();
         singleGroup.addInspections(inspection);
         WarpResult result = execute();
-        return (T) result.getGroup(SingleInspectionSpecifier.GROUP_ID).getInspection();
+        return result.getGroup(SingleInspectionSpecifier.GROUP_ID).<T>getInspection();
     }
 
     /*

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/DefaultWarpRequestSpecifier.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/DefaultWarpRequestSpecifier.java
@@ -73,7 +73,7 @@ public class DefaultWarpRequestSpecifier implements WarpRequestSpecifier {
         initializeSingleGroup();
         singleGroup.addInspections(inspection);
         WarpResult result = execute();
-        return result.getGroup(SingleInspectionSpecifier.GROUP_ID).<T>getInspection();
+        return result.getGroup(SingleInspectionSpecifier.GROUP_ID).getInspection();
     }
 
     /*

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/WarpGroupImpl.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/WarpGroupImpl.java
@@ -126,6 +126,7 @@ public class WarpGroupImpl implements WarpGroup {
      * (non-Javadoc)
      * @see org.jboss.arquillian.warp.client.result.WarpGroupResult#getInspection()
      */
+    @SuppressWarnings("unchecked")
     @Override
     public <T extends Inspection> T getInspection() {
         return (T) payloads.values().iterator().next().getInspections().get(0);
@@ -135,6 +136,7 @@ public class WarpGroupImpl implements WarpGroup {
      * (non-Javadoc)
      * @see org.jboss.arquillian.warp.client.result.WarpGroupResult#getInspectionForHitNumber(int)
      */
+    @SuppressWarnings("unchecked")
     @Override
     public <T extends Inspection> T getInspectionForHitNumber(int hitNumber) {
         return (T) getInspectionsForHitNumber(hitNumber).get(0);

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/server/commandBus/CommandServiceOnServer.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/server/commandBus/CommandServiceOnServer.java
@@ -43,7 +43,9 @@ public class CommandServiceOnServer implements CommandService {
                 if (responsePayload.getThrowable() != null) {
                     Rethrow.asUnchecked(responsePayload.getThrowable());
                 }
-                return (T) responsePayload.getCommand();
+                @SuppressWarnings("unchecked")
+                T command = (T)responsePayload.getCommand();
+                return command;
             }
             try {
                 Thread.sleep(100);

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestRequestExecutionSynchronization.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestRequestExecutionSynchronization.java
@@ -42,7 +42,7 @@ import org.jboss.arquillian.warp.impl.client.scope.WarpExecutionContext;
 import org.jboss.arquillian.warp.impl.client.testbase.AbstractWarpClientTestTestBase;
 import org.jboss.arquillian.warp.impl.shared.RequestPayload;
 import org.jboss.arquillian.warp.impl.shared.ResponsePayload;
-import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -337,7 +337,7 @@ public class TestRequestExecutionSynchronization extends AbstractWarpClientTestT
     @RunAsClient
     public static final class TestingClass {
         @Deployment
-        public static Archive deploy() {
+        public static JavaArchive deploy() {
             return null;
         }
     }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/filter/http/TestHttpFilters.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/filter/http/TestHttpFilters.java
@@ -41,7 +41,7 @@ import org.jboss.arquillian.warp.impl.client.execution.WarpExecutionObserver;
 import org.jboss.arquillian.warp.impl.client.execution.WarpExecutor;
 import org.jboss.arquillian.warp.impl.client.execution.WarpRequestSpecifier;
 import org.jboss.arquillian.warp.impl.client.testbase.AbstractWarpClientTestTestBase;
-import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -420,7 +420,7 @@ public class TestHttpFilters extends AbstractWarpClientTestTestBase {
     @RunAsClient
     public static final class TestingClass {
         @Deployment
-        public static Archive deploy() {
+        public static JavaArchive deploy() {
             return null;
         }
     }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/shared/inspection/TestInspectionLoading.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/shared/inspection/TestInspectionLoading.java
@@ -103,7 +103,7 @@ public class TestInspectionLoading {
             replaceClassLoader(serverClassLoader);
             Object deserializedPayload = deserialize(serialized);
             Method getInspectionsMethod = deserializedPayload.getClass().getMethod("getInspections");
-            List deserializedInspectionList = (List) getInspectionsMethod.invoke(deserializedPayload);
+            List<?> deserializedInspectionList = (List<?>) getInspectionsMethod.invoke(deserializedPayload);
             Object deserializedInspection = deserializedInspectionList.iterator().next();
 
             Class<?> deserializedClass = deserializedInspection.getClass();

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/SeparatedClassloaderRunner.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/SeparatedClassloaderRunner.java
@@ -187,6 +187,7 @@ public class SeparatedClassloaderRunner extends BlockJUnit4ClassRunner {
 
         try {
 
+            @SuppressWarnings("unchecked")
             Class<? extends Annotation> testAnnotation = (Class<? extends Annotation>) classLoader.loadClass(Test.class
                 .getName());
             return getTestClass().getAnnotatedMethods(testAnnotation);

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/TestSeparateClassLoader.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/TestSeparateClassLoader.java
@@ -36,6 +36,7 @@ public class TestSeparateClassLoader {
 
         Method method = loadedClass.getMethod("test");
 
+        @SuppressWarnings("unchecked")
         Class<? extends Annotation> testAnnotation =
             (Class<? extends Annotation>) classLoader.loadClass(Test.class.getName());
 


### PR DESCRIPTION
This fixes all Eclipse warnings about generics. I hope my resolutions are OK.

I am not sure about the existing implementation of the method `WarpGroupImpl.getInspection`: it does not seem to be a good candiate for a generic return value, as there is no check whether the result is really the generic `Inspection` implementation or not. But removing the generic result would bubble up...

The other big change was to make `ProxyObserver` generic. This seems to be more reasonable, as it contain a `ProxyHolder` that is already generic, but in the end there is no need to do so ;-).

If this pull request is accepted, I would care for the remaining warnings (mostly unused code)