### PR TITLE
Removed warnings about unused code or missing serialVersionUID and fixed one real error

### DIFF
--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/BasicJsfTest.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/BasicJsfTest.java
@@ -119,6 +119,7 @@ public class BasicJsfTest {
                              updatedName = myBean.getName();
                          }
 
+                         @SuppressWarnings("unused")
                          public String getUpdatedName() {
                              return updatedName;
                          }

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/failure/TestSerializationFailurePropagation.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/failure/TestSerializationFailurePropagation.java
@@ -82,6 +82,7 @@ public class TestSerializationFailurePropagation {
                 .inspect(new Inspection() {
                              private static final long serialVersionUID = 1L;
 
+                             @SuppressWarnings("unused")
                              private Object payload = new NonSerializableObject();
 
                              @BeforeServlet
@@ -113,6 +114,7 @@ public class TestSerializationFailurePropagation {
                 .inspect(new Inspection() {
                              private static final long serialVersionUID = 1L;
 
+                             @SuppressWarnings("unused")
                              private Object payload;
 
                              @BeforeServlet

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultHttpHeaderMatcherBuilder.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultHttpHeaderMatcherBuilder.java
@@ -99,7 +99,7 @@ public class DefaultHttpHeaderMatcherBuilder extends AbstractMatcherFilterBuilde
 
                 for (String val : values) {
 
-                    if (val.equals(values)) {
+                    if (val.equals(value)) {
 
                         return true;
                     }

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/proxy/ProxyURLProvider.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/proxy/ProxyURLProvider.java
@@ -97,7 +97,7 @@ public class ProxyURLProvider implements ResourceProvider {
         return proxyURL;
     }
 
-    private Injector injector() {
+    /*private Injector injector() {
         return injector.get();
-    }
+    }*/
 }

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/utils/Platform.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/utils/Platform.java
@@ -17,9 +17,6 @@
 
 package org.jboss.arquillian.warp.impl.utils;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * Represents the known and supported Platforms that WebDriver runs on. This is pretty close to the
  * Operating System, but differs slightly, because this class is used to extract information such as
@@ -135,10 +132,6 @@ public enum Platform {
     },
 
     ANDROID("android", "dalvik") {
-        public String getLineEnding() {
-            return "\n";
-        }
-
         @Override
         public Platform family() {
             return LINUX;
@@ -156,12 +149,13 @@ public enum Platform {
     };
 
     private final String[] partOfOsName;
-    private final int minorVersion;
-    private final int majorVersion;
+    //private final int minorVersion;
+    //private final int majorVersion;
 
     Platform(String... partOfOsName) {
         this.partOfOsName = partOfOsName;
 
+        /*Unused...
         String version = System.getProperty("os.version", "0.0.0");
         int major = 0;
         int min = 0;
@@ -178,7 +172,7 @@ public enum Platform {
         }
 
         majorVersion = major;
-        minorVersion = min;
+        minorVersion = min;*/
     }
 
     public String[] getPartOfOsName() {

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/eventbus/TestCommandEventBusLifecycle.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/eventbus/TestCommandEventBusLifecycle.java
@@ -85,9 +85,11 @@ public class TestCommandEventBusLifecycle extends AbstractTestTestBase {
     }
 
     private static class StartBlockingObserver {
+        @SuppressWarnings("unused")
         public void blockStart(@Observes EventContext<StartBus> ctx) {
         }
 
+        @SuppressWarnings("unused")
         public void blockStop(@Observes EventContext<StopBus> ctx) {
         }
     }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/separation/TestSeparateInvocator.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/separation/TestSeparateInvocator.java
@@ -47,9 +47,16 @@ public class TestSeparateInvocator {
         }
     }
 
+    /**
+     * Must be public. If not the test is failing:
+     * "java.lang.IllegalAccessError: tried to access class org.jboss.arquillian.warp.impl.client.separation.TestSeparateInvocator$Result
+     * from class com.sun.proxy.$Proxy4"
+     */
+    @SuppressWarnings("serial")
     public static class Result implements Serializable {
     }
 
+    @SuppressWarnings("serial")
     public static class Argument implements Serializable {
     }
 }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/separation/TestSeparatedClassLoader.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/separation/TestSeparatedClassLoader.java
@@ -156,6 +156,7 @@ public class TestSeparatedClassLoader {
         SeparatedClassLoader separated = new SeparatedClassLoader(cl1, cl2);
 
         try {
+            @SuppressWarnings("unused")
             Class<?> loadedClass = separated.loadClass("SomeNonExistingClassName");
             fail("class should not be found");
         } catch (ClassNotFoundException e) {

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/transformation/TestTransformedInspection.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/transformation/TestTransformedInspection.java
@@ -127,7 +127,6 @@ public class TestTransformedInspection {
         Inspection inspection = new Inspection() {
             private static final long serialVersionUID = 1L;
 
-            @SuppressWarnings("unused")
             @BeforeServlet
             public String get() {
                 return "Test";

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/shared/inspection/SharingClass.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/shared/inspection/SharingClass.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 import org.jboss.arquillian.warp.Inspection;
 import org.jboss.arquillian.warp.impl.shared.RequestPayload;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({ "unused", "serial" })
 public class SharingClass implements Serializable {
 
     public RequestPayload getStaticInnerClass() {

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/TestDynamicClassLoading.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/TestDynamicClassLoading.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 @RunWith(SeparatedClassloaderRunner.class)
 public class TestDynamicClassLoading {
 
+    @SuppressWarnings({ "unused", "serial" })
     private Inspection inspection = new Inspection() {
     };
 
@@ -35,6 +36,7 @@ public class TestDynamicClassLoading {
 
     @Test
     public void test() {
+        @SuppressWarnings("unused")
         String test = "xyz";
     }
 }


### PR DESCRIPTION
The real error is in /arquillian-warp-impl/src/main/java/org/jboss/arquillian/warp/impl/client/filter/matcher/DefaultHttpHeaderMatcherBuilder.java, line 102

`if (val.equals(values)) {`

The warning was: "Unlikely argument type for equals(): List<String> seems to be unrelated to String"

Yes, it should probably check for the argument "value":

```
    public HttpFilterBuilder containsValue(final String name, final String value) {
        return addFilter(new RequestFilter<HttpRequest>() {
            @Override
            public boolean matches(HttpRequest request) {
                List<String> values = request.getHeaders(name);
                for (String val : values) {
                    if (val.equals(value)) {
                        return true;
                    }
                }
                return false;
            }
            ...
        });
    }
```

I commented a bit of unused code in "Platform" - I am quite sure that it is really unused, but who knows ;-). I can remove it if you prefer to do so.