### PR TITLE
Removed hamcrest dependency

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -94,12 +94,6 @@
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
       </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-all</artifactId>
-        <version>${version.hamcrest}</version>
-        <scope>test</scope>
-      </dependency>
 
       <!-- Mockito -->
       <dependency>

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -42,11 +42,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
 
     <!-- Tests -->
     <version.junit>4.13.2</version.junit>
-    <version.hamcrest>1.3</version.hamcrest>
     <version.mockito>4.9.0</version.mockito>
     <version.jacoco>0.8.11</version.jacoco>
     <version.shrinkwrap.resolver>3.2.1</version.shrinkwrap.resolver>


### PR DESCRIPTION
org.hamcrest:hamcrest-all 1.3 is replaced by e.g. "org.hamcrest:hamcrest-core:jar:2.2", that is already bundled by JUnit:

```
[INFO] --- dependency:3.1.1:tree (default-cli) @ arquillian-warp-api ---
[INFO] org.jboss.arquillian.extension:arquillian-warp-api:jar:1.0.1-SNAPSHOT
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:2.2:test
[INFO] |     \- org.hamcrest:hamcrest:jar:2.2:test
```

We could also declare the new dependency explicitly.