### PR TITLE
Update arquillian-core from 1.7.1 to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
   <properties>
     <!-- Arquillian -->
     <version.servlet_api>3.0.1</version.servlet_api>
-    <version.arquillian_core>1.7.1.Final</version.arquillian_core>
+    <version.arquillian_core>1.8.0.Final</version.arquillian_core>
     <version.arquillian_drone>3.0.0-alpha.7</version.arquillian_drone>
     <version.arquillian_jacoco>1.1.0</version.arquillian_jacoco>
 


### PR DESCRIPTION
This Arquillian update fixes the glassfish fileleak from #131

I saw that there changes in arquillian regarding the JakartaEE compatibility, but at least the test suite still works for me. Hope that the new version does not break anything else ;-).