### PR TITLE
Revert wildfly-arquillian-container to 4.0.1.Final

### DIFF
--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/BasicJsfTest.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/BasicJsfTest.java
@@ -41,7 +41,6 @@ import org.jboss.arquillian.warp.jsf.BeforePhase;
 import org.jboss.arquillian.warp.jsf.ftest.cdi.CdiBean;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
@@ -50,7 +49,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-@Ignore
 @RunWith(Arquillian.class)
 @WarpTest
 @RunAsClient

--- a/ftest/src/test/java/org/jboss/arquillian/warp/ftest/cdi/CdiWarpTest.java
+++ b/ftest/src/test/java/org/jboss/arquillian/warp/ftest/cdi/CdiWarpTest.java
@@ -37,7 +37,6 @@ import org.jboss.arquillian.warp.servlet.BeforeServlet;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
@@ -46,7 +45,6 @@ import org.openqa.selenium.WebDriver;
 /**
  * @author Lukas Fryc
  */
-@Ignore
 @RunWith(Arquillian.class)
 @WarpTest
 @RunAsClient

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <version.tomcat7>7.0.26</version.tomcat7>
     <!-- Don't upgrade beyond WildFly 26 for EE 8, WF 27 and newer is Jakarta EE 10 -->
     <version.wildfly>26.1.3.Final</version.wildfly>
-    <version.wildfly.arquillian.container>5.0.0.Final</version.wildfly.arquillian.container>
+    <version.wildfly.arquillian.container>4.0.1.Final</version.wildfly.arquillian.container>
 
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>


### PR DESCRIPTION
Resolves #203 

"wildfly-arquillian-container-managed" 5.0 does not seem to be compatible with WildFly 26 / JavaEE8 and breaks dependency injection.

This is a temporary fix. After updating to JakartaEE10, we have to go to 5.0 again.