### PR TITLE
Update to LittleProxy 2.3.0 (new groupid)

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -69,7 +69,7 @@
 
       <!-- LittleProxy -->
       <dependency>
-        <groupId>xyz.rogfam</groupId>
+        <groupId>io.github.littleproxy</groupId>
         <artifactId>littleproxy</artifactId>
         <version>${version.littleproxy}</version>
       </dependency>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -52,7 +52,7 @@
 
     <!-- Little Proxy -->
     <dependency>
-      <groupId>xyz.rogfam</groupId>
+      <groupId>io.github.littleproxy</groupId>
       <artifactId>littleproxy</artifactId>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <version.arquillian_drone>3.0.0-alpha.8</version.arquillian_drone>
     <version.arquillian_jacoco>1.1.0</version.arquillian_jacoco>
 
-    <version.littleproxy>2.0.22</version.littleproxy>
+    <version.littleproxy>2.3.0</version.littleproxy>
     <!--Littleproxy logging is done through SL4J and thus Log4j: -->
     <version.log4j>2.24.0</version.log4j>
     <version.javassist>3.30.2-GA</version.javassist>


### PR DESCRIPTION
Resolves #179 - the LittleProxy maven artifact has a new groupid: "io.github.littleproxy" instead of "xyz.rogfam".
Also updated to recent release 2.3.0

Supersedes #178