### PR TITLE
TomEE profile: switch to TomEE 10 M3, wildfly-arquillian-container 5.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,12 @@ jobs:
           - wildfly-managed
           # TODO GlassFish 5 is not compatible with JDK 9 and newer
           # - glassfish-managed
-          # TODO Upgrade to compatible TomEE version
-          # - tomee-managed
+           - tomee-managed
+        exclude:
+           # TomEE 10 requires Java 17.
+           - os: ubuntu-latest
+             java: 11
+             container: tomee-managed
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           - wildfly-managed
           # TODO GlassFish 5 is not compatible with JDK 9 and newer
           # - glassfish-managed
-           - tomee-managed
+          - tomee-managed
         exclude:
            # TomEE 10 requires Java 17.
            - os: ubuntu-latest

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -188,22 +188,53 @@
         </arquillian.container.distribution>
       </properties>
       <dependencies>
+        <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
+            test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
+
+            Also, it must be declared before "org.apache.tomee:arquillian-tomee-remote", because the latter brings "org.apache.tomee:jakartaee-api",
+            which also contains a "ServletException", but with a different SerialVersionUID. Thus the error described in "TestFacesLifecycleFailurePropagation"
+            would occur.
+            If we declare the servlet api jar before the arquillian jar, the ServletException class is loaded from there.
+          -->
+        <dependency>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-servlet-api</artifactId>
+          <scope>provided</scope>
+          <version>${version.tomee.tomcat}</version>
+        </dependency>
         <dependency>
           <groupId>org.apache.tomee</groupId>
           <artifactId>arquillian-tomee-remote</artifactId>
           <version>${version.tomee}</version>
           <scope>test</scope>
         </dependency>
-        <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
-            test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
-          -->
-        <dependency>
-          <groupId>org.apache.tomcat</groupId>
-          <artifactId>tomcat-servlet-api</artifactId>
-          <scope>provided</scope>
-          <version>${version.tomee}</version>
-        </dependency>
       </dependencies>
+
+      <!--This profile requires Java 17 to run, as this is required by TomEE -->
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.5.0</version>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <version>17</version>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <!-- Don't run this profile on windows: the test performance will be incredibly poor (90 seconds per test).

--- a/extension/jsf-ftest/src/main/webapp/WEB-INF/beans.xml
+++ b/extension/jsf-ftest/src/main/webapp/WEB-INF/beans.xml
@@ -17,5 +17,8 @@
     limitations under the License.
 
 -->
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd">
+<beans version="4.0"
+   xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+   bean-discovery-mode="annotated">
 </beans>

--- a/extension/jsf-ftest/src/main/webapp/WEB-INF/web.xml
+++ b/extension/jsf-ftest/src/main/webapp/WEB-INF/web.xml
@@ -17,9 +17,10 @@
     limitations under the License.
 
 -->
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0">
 
   <!-- Set the PROJECT_STAGE to 'Development' to receive constructive error messages during development.
   Change the PROJECT_STAGE to 'Production' when putting the application into production -->

--- a/extension/jsf-ftest/src/main/webapp/index.xhtml
+++ b/extension/jsf-ftest/src/main/webapp/index.xhtml
@@ -19,9 +19,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 
 <body>
 <ui:composition template="/templates/template.xhtml">

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/BasicJsfTest.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/BasicJsfTest.java
@@ -21,6 +21,7 @@ import static org.jboss.arquillian.warp.jsf.Phase.UPDATE_MODEL_VALUES;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.function.Function;
@@ -41,6 +42,8 @@ import org.jboss.arquillian.warp.jsf.BeforePhase;
 import org.jboss.arquillian.warp.jsf.ftest.cdi.CdiBean;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
@@ -69,6 +72,14 @@ public class BasicJsfTest {
             .addAsWebResource(new File("src/main/webapp/templates/template.xhtml"), "templates/template.xhtml")
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml"))
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/faces-config.xml"));
+    }
+
+    /**Exclude this test for TomEE as long as the HtmlUnit issue is not fixed,
+     * see https://github.com/arquillian/arquillian-extension-warp/issues/242  */
+    @BeforeClass
+    public static void beforeClass() throws IOException, InterruptedException {
+       String tomEEHome = (String) System.getProperty("tomee.home");
+       Assume.assumeTrue(tomEEHome == null || tomEEHome.length() == 0);
     }
 
     @Test

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/failure/TestInspectionFailurePropagation.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/failure/TestInspectionFailurePropagation.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.warp.jsf.ftest.failure;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -34,6 +35,8 @@ import org.jboss.arquillian.warp.jsf.ftest.cdi.CdiBean;
 import org.jboss.arquillian.warp.servlet.BeforeServlet;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
@@ -58,6 +61,14 @@ public class TestInspectionFailurePropagation {
             .addAsWebResource(new File("src/main/webapp/templates/template.xhtml"), "templates/template.xhtml")
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml"))
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/faces-config.xml"));
+    }
+
+    /**Exclude this test for TomEE as long as the HtmlUnit issue is not fixed,
+     * see https://github.com/arquillian/arquillian-extension-warp/issues/242  */
+    @BeforeClass
+    public static void beforeClass() throws IOException, InterruptedException {
+       String tomEEHome = (String) System.getProperty("tomee.home");
+       Assume.assumeTrue(tomEEHome == null || tomEEHome.length() == 0);
     }
 
     @Test(expected = AssertionError.class)

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestJsfLifecycle.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/lifecycle/TestJsfLifecycle.java
@@ -17,6 +17,7 @@
 package org.jboss.arquillian.warp.jsf.ftest.lifecycle;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.function.Function;
@@ -37,6 +38,8 @@ import org.jboss.arquillian.warp.jsf.ftest.cdi.CdiBean;
 import org.jboss.arquillian.warp.servlet.BeforeServlet;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
@@ -64,6 +67,14 @@ public class TestJsfLifecycle {
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/beans.xml"))
             .addAsWebResource(new File("src/main/webapp/templates/template.xhtml"), "templates/template.xhtml")
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/faces-config.xml"));
+    }
+
+    /**Exclude this test for TomEE as long as the HtmlUnit issue is not fixed,
+     * see https://github.com/arquillian/arquillian-extension-warp/issues/242  */
+    @BeforeClass
+    public static void beforeClass() throws IOException, InterruptedException {
+       String tomEEHome = (String) System.getProperty("tomee.home");
+       Assume.assumeTrue(tomEEHome == null || tomEEHome.length() == 0);
     }
 
     @Test

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFInstanceProducers.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFInstanceProducers.java
@@ -17,6 +17,7 @@
 package org.jboss.arquillian.warp.jsf.ftest.producer;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -32,6 +33,8 @@ import org.jboss.arquillian.warp.WarpTest;
 import org.jboss.arquillian.warp.jsf.ftest.cdi.CdiBean;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
@@ -58,6 +61,14 @@ public class TestJSFInstanceProducers {
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml"))
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/faces-config.xml"))
             .addAsServiceProvider(RemoteLoadableExtension.class, TestingExtension.class);
+    }
+
+    /**Exclude this test for TomEE as long as the HtmlUnit issue is not fixed,
+     * see https://github.com/arquillian/arquillian-extension-warp/issues/242  */
+    @BeforeClass
+    public static void beforeClass() throws IOException, InterruptedException {
+       String tomEEHome = (String) System.getProperty("tomee.home");
+       Assume.assumeTrue(tomEEHome == null || tomEEHome.length() == 0);
     }
 
     @Test

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceProviders.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceProviders.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.warp.jsf.ftest.producer;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 
 import jakarta.el.ELContext;
@@ -52,6 +53,8 @@ import org.jboss.arquillian.warp.jsf.Phase;
 import org.jboss.arquillian.warp.jsf.ftest.cdi.CdiBean;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
@@ -77,6 +80,14 @@ public class TestJSFResourceProviders {
             .addAsWebResource(new File("src/main/webapp/templates/template.xhtml"), "templates/template.xhtml")
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml"))
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/faces-config.xml"));
+    }
+
+    /**Exclude this test for TomEE as long as the HtmlUnit issue is not fixed,
+     * see https://github.com/arquillian/arquillian-extension-warp/issues/242  */
+    @BeforeClass
+    public static void beforeClass() throws IOException, InterruptedException {
+       String tomEEHome = (String) System.getProperty("tomee.home");
+       Assume.assumeTrue(tomEEHome == null || tomEEHome.length() == 0);
     }
 
     @Test

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFTestEnrichers.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFTestEnrichers.java
@@ -36,6 +36,7 @@ import org.jboss.arquillian.warp.WarpTest;
 import org.jboss.arquillian.warp.jsf.AfterPhase;
 import org.jboss.arquillian.warp.jsf.BeforePhase;
 import org.jboss.arquillian.warp.jsf.Phase;
+import org.jboss.arquillian.warp.jsf.ftest.cdi.CdiBean;
 import org.jboss.arquillian.warp.jsf.ftest.faces.FacesBean;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -59,6 +60,8 @@ public class TestJSFTestEnrichers {
 
         return ShrinkWrap.create(WebArchive.class, "jsf-test.war")
             .addClasses(FacesBean.class)
+            //Not required for a successful unit test, but it is used on "index.xhtml".
+            .addClasses(CdiBean.class)
             .addAsWebResource(new File("src/main/webapp/index.xhtml"))
             .addAsWebResource(new File("src/main/webapp/templates/template.xhtml"), "templates/template.xhtml")
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml"))

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFTestEnrichers.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFTestEnrichers.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.warp.jsf.ftest.producer;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 
 import jakarta.faces.event.PhaseId;
@@ -40,6 +41,8 @@ import org.jboss.arquillian.warp.jsf.ftest.cdi.CdiBean;
 import org.jboss.arquillian.warp.jsf.ftest.faces.FacesBean;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
@@ -66,6 +69,14 @@ public class TestJSFTestEnrichers {
             .addAsWebResource(new File("src/main/webapp/templates/template.xhtml"), "templates/template.xhtml")
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml"))
             .addAsWebInfResource(new File("src/main/webapp/WEB-INF/faces-config.xml"));
+    }
+
+    /**Exclude this test for TomEE as long as the HtmlUnit issue is not fixed,
+     * see https://github.com/arquillian/arquillian-extension-warp/issues/242  */
+    @BeforeClass
+    public static void beforeClass() throws IOException, InterruptedException {
+       String tomEEHome = (String) System.getProperty("tomee.home");
+       Assume.assumeTrue(tomEEHome == null || tomEEHome.length() == 0);
     }
 
     @Test

--- a/ftest/src/main/webapp/WEB-INF/web-redirect.xml
+++ b/ftest/src/main/webapp/WEB-INF/web-redirect.xml
@@ -17,9 +17,10 @@
     limitations under the License.
 
 -->
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+    version="6.0">
 
   <filter>
     <filter-name>RedirectFilter</filter-name>

--- a/pom.xml
+++ b/pom.xml
@@ -95,10 +95,14 @@
     <modular.jdk.args />
 
     <!-- Container Versions -->
-    <version.tomee>8.0.14</version.tomee>
+    <version.tomee>10.0.0-M3</version.tomee>
+    <!-- Tomcat version bundled with TomEE - see https://tomee.apache.org/comparison.html
+         The version can be found in "bin/servlet-api.jar"
+         It does not have to match exactly the version bundled with TomEE, but it should be at least the same JakartaEE spec version.-->
+    <version.tomee.tomcat>10.1.30</version.tomee.tomcat>
     <version.glassfish>5.1.0</version.glassfish>
     <version.wildfly>33.0.0.Final</version.wildfly>
-    <version.wildfly.arquillian.container>5.0.0.Final</version.wildfly.arquillian.container>
+    <version.wildfly.arquillian.container>5.0.1.Final</version.wildfly.arquillian.container>
   </properties>
 
   <modules>


### PR DESCRIPTION
Partially resolves #242: TomEE 10 is JakartaEE10 compliant, but not final. More details in this issue.

Also updates the constant "version.wildfly.arquillian.container" to "5.0.1.Final" (don't know why dependabot did not pick it).