### PR TITLE
Dependabot: Don't upgrade spec dependencies past Jakarta EE 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
         versions: "[5,)"
       - dependency-name: org.mockito:mockito-inline
         versions: "[5,)"
+      # Don't upgrade spec dependencies past Jakarta EE 10
+      - dependency-name: jakarta.faces:jakarta.faces-api
+        version: "[4.1.0,)"
+      - dependency-name: jakarta.annotation:jakarta.annotation-api
+        version: "[3.0.0,)"
+      - dependency-name: jakarta.servlet:jakarta.servlet-api
+        version: "[6.1.0,)"
+      - dependency-name: jakarta.enterprise:jakarta.enterprise.cdi-api
+        version: "[4.1.0,)"


### PR DESCRIPTION
This will close existing EE 11 spec upgrades which are constantly rebased and waste resources.