### PR TITLE
Dependabot: Don't upgrade tomcat servlet api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,6 @@ updates:
         versions: "[6.1.0,)"
       - dependency-name: jakarta.enterprise:jakarta.enterprise.cdi-api
         versions: "[4.1.0,)"
+      # Don't upgrade the tomcat servlet api, as it should match the TomEE version, which most probably does not contain a recent version of this artifact.
+      - dependency-name: org.apache.tomcat:tomcat-servlet-api
+        versions: "[10.1.0,)"


### PR DESCRIPTION
The Tomcat servlet api version depends on the TomEE version and TomEE probably never contains the most recent available version. So ignore it. Whenever the TomEE version is updated, the servlet api version has to be checked.

This should close #246