### PR TITLE
Restore testsuite for Glassfish 7, switch to "org.omnifaces.arquillia…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
           - 23
         container:
           - wildfly-managed
-          # TODO GlassFish 5 is not compatible with JDK 9 and newer
-          # - glassfish-managed
+          - glassfish-managed
           - tomee-managed
         exclude:
            # TomEE 10 requires Java 17.

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.shrinkwrap.descriptors>2.0.0</version.shrinkwrap.descriptors>
-    <version.arquillian.glassfish>1.0.2</version.arquillian.glassfish>
+    <version.arquillian.glassfish>1.6</version.arquillian.glassfish>
 
     <!-- Arquillian Configuration -->
     <arquillian.debug>false</arquillian.debug>
@@ -250,14 +250,20 @@
       </activation>
       <properties>
         <arquillian.launch.glassfish>true</arquillian.launch.glassfish>
-        <arquillian.container.home>${project.build.directory}/glassfish5</arquillian.container.home>
+        <arquillian.container.home>${project.build.directory}/glassfish7</arquillian.container.home>
         <arquillian.container.distribution>org.glassfish.main.distributions:glassfish:zip:${version.glassfish}
         </arquillian.container.distribution>
       </properties>
+
       <dependencies>
+
+        <!--The original glassfish container is abandoned and does not support glassfish 7
+            (https://github.com/arquillian/arquillian-container-glassfish and https://github.com/arquillian/arquillian-container-glassfish6),
+            so use a fork at https://github.com/OmniFish-EE/arquillian-container-glassfish <dependency>
+        -->
         <dependency>
-          <groupId>org.jboss.arquillian.container</groupId>
-          <artifactId>arquillian-glassfish-managed-3.1</artifactId>
+          <groupId>org.omnifaces.arquillian</groupId>
+          <artifactId>arquillian-glassfish-server-managed</artifactId>
           <version>${version.arquillian.glassfish}</version>
           <scope>test</scope>
         </dependency>
@@ -295,8 +301,8 @@
       </properties>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.arquillian.container</groupId>
-          <artifactId>arquillian-glassfish-remote-3.1</artifactId>
+          <groupId>org.omnifaces.arquillian</groupId>
+          <artifactId>arquillian-glassfish-server-remote</artifactId>
           <version>${version.arquillian.glassfish}</version>
           <scope>test</scope>
         </dependency>

--- a/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceNotFound.java
+++ b/extension/jsf-ftest/src/test/java/org/jboss/arquillian/warp/jsf/ftest/producer/TestJSFResourceNotFound.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.arquillian.warp.jsf.ftest.producer;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
@@ -31,7 +32,6 @@ import org.jboss.arquillian.warp.Inspection;
 import org.jboss.arquillian.warp.Warp;
 import org.jboss.arquillian.warp.WarpTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,11 +51,12 @@ public class TestJSFResourceNotFound {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "jsf-test.war")
-            .addAsWebInfResource(new StringAsset("<faces-config version=\"2.0\" xmlns=\"http://java.sun.com/xml/ns/javaee\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd\"></faces-config>"), "faces-config.xml")
+            .addAsWebInfResource(new File("src/main/webapp/WEB-INF/faces-config.xml"))
+            .addAsWebInfResource(new File("src/main/webapp/WEB-INF/beans.xml"))
             //The test for GlassFish will fail without "web.xml" with a "java.io.IOException: Server returned HTTP response code: 500 for URL: http://127.0.0.1:10186/jsf-test/faces/notExisting.xhtml"
             //instead of the expected "FileNotFoundException".
             //On other servers, it works as expected.
-            .addAsWebInfResource(new java.io.File("src/main/webapp/WEB-INF/web.xml"));
+            .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
          The version can be found in "bin/servlet-api.jar"
          It does not have to match exactly the version bundled with TomEE, but it should be at least the same JakartaEE spec version.-->
     <version.tomee.tomcat>10.1.30</version.tomee.tomcat>
-    <version.glassfish>5.1.0</version.glassfish>
+    <version.glassfish>7.0.18</version.glassfish>
     <version.wildfly>33.0.0.Final</version.wildfly>
     <version.wildfly.arquillian.container>5.0.1.Final</version.wildfly.arquillian.container>
 


### PR DESCRIPTION
…n" container

Switch to GlassFish 7 (JakartaEE 10 compliant) and https://github.com/OmniFish-EE/arquillian-container-glassfish.

There is one modification to the test "org.jboss.arquillian.warp.jsf.ftest.producer.TestJSFResourceNotFound": the deployed war file requires a "bean.xml", otherwise the test failed with `IllegalStateException: CDI is not available`
Should have no impact on other containers.

(Mostly) resolves #131. The file leak problem from this issue still happens on Windows - every test has a delay of 20 seconds when Glassfish waits for locked files. Should not be a problem with Linux. Please keep #131 open until I find time to look into this. 

Let's see whether the CI test works again. If it works, this pull request can be merged. If it fails: I will probably not have the time to look into it the next few days.

