### PR TITLE
Deprecation: remove isAccessible

### DIFF
--- a/extension/jsf/src/main/java/org/jboss/arquillian/warp/jsf/enricher/SecurityActions.java
+++ b/extension/jsf/src/main/java/org/jboss/arquillian/warp/jsf/enricher/SecurityActions.java
@@ -131,9 +131,7 @@ final class SecurityActions {
         final T obj;
         try {
             Constructor<T> constructor = getConstructor(implClass, argumentTypes);
-            if (!constructor.isAccessible()) {
-                constructor.setAccessible(true);
-            }
+            constructor.setAccessible(true);
             obj = constructor.newInstance(arguments);
         } catch (Exception e) {
             throw new RuntimeException("Could not create new instance of " + implClass, e);
@@ -193,9 +191,7 @@ final class SecurityActions {
                 @Override
                 public Void run() throws Exception {
                     Field field = source.getDeclaredField(fieldName);
-                    if (!field.isAccessible()) {
-                        field.setAccessible(true);
-                    }
+                    field.setAccessible(true);
                     field.set(target, value);
                     return null;
                 }
@@ -229,9 +225,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Field field : nextSource.getDeclaredFields()) {
                         if (field.isAnnotationPresent(annotationClass)) {
-                            if (!field.isAccessible()) {
-                                field.setAccessible(true);
-                            }
+                            field.setAccessible(true);
                             foundFields.add(field);
                         }
                     }
@@ -252,9 +246,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Method method : nextSource.getDeclaredMethods()) {
                         if (method.isAnnotationPresent(annotationClass)) {
-                            if (!method.isAccessible()) {
-                                method.setAccessible(true);
-                            }
+                            method.setAccessible(true);
                             foundMethods.add(method);
                         }
                     }

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/SecurityActions.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/SecurityActions.java
@@ -167,9 +167,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Field field : nextSource.getDeclaredFields()) {
                         if (field.isAnnotationPresent(annotationClass)) {
-                            if (!field.isAccessible()) {
-                                field.setAccessible(true);
-                            }
+                            field.setAccessible(true);
                             foundFields.add(field);
                         }
                     }
@@ -190,9 +188,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Method method : nextSource.getDeclaredMethods()) {
                         if (method.isAnnotationPresent(annotationClass)) {
-                            if (!method.isAccessible()) {
-                                method.setAccessible(true);
-                            }
+                            method.setAccessible(true);
                             foundMethods.add(method);
                         }
                     }
@@ -247,9 +243,7 @@ final class SecurityActions {
                 Class<?> nextSource = source;
                 while (nextSource != Object.class) {
                     for (Field field : nextSource.getDeclaredFields()) {
-                        if (!field.isAccessible()) {
-                            field.setAccessible(true);
-                        }
+                        field.setAccessible(true);
                         foundFields.add(field);
                     }
                     nextSource = nextSource.getSuperclass();

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/verification/SecurityActions.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/verification/SecurityActions.java
@@ -168,9 +168,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Field field : nextSource.getDeclaredFields()) {
                         if (field.isAnnotationPresent(annotationClass)) {
-                            if (!field.isAccessible()) {
-                                field.setAccessible(true);
-                            }
+                            field.setAccessible(true);
                             foundFields.add(field);
                         }
                     }
@@ -208,9 +206,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Method method : nextSource.getDeclaredMethods()) {
                         if (method.isAnnotationPresent(annotationClass)) {
-                            if (!method.isAccessible()) {
-                                method.setAccessible(true);
-                            }
+                            method.setAccessible(true);
                             foundMethods.add(method);
                         }
                     }
@@ -265,9 +261,7 @@ final class SecurityActions {
                 Class<?> nextSource = source;
                 while (nextSource != Object.class) {
                     for (Field field : nextSource.getDeclaredFields()) {
-                        if (!field.isAccessible()) {
-                            field.setAccessible(true);
-                        }
+                        field.setAccessible(true);
                         foundFields.add(field);
                     }
                     nextSource = nextSource.getSuperclass();

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/server/test/LifecycleTestEnrichmentWatcher.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/server/test/LifecycleTestEnrichmentWatcher.java
@@ -110,9 +110,7 @@ public class LifecycleTestEnrichmentWatcher {
                     continue;
                 }
 
-                if (!field.isAccessible()) {
-                    field.setAccessible(true);
-                }
+                field.setAccessible(true);
                 field.set(instance, oldValue);
             }
         } catch (Exception e) {

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/server/test/SecurityActions.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/server/test/SecurityActions.java
@@ -168,9 +168,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Field field : nextSource.getDeclaredFields()) {
                         if (field.isAnnotationPresent(annotationClass)) {
-                            if (!field.isAccessible()) {
-                                field.setAccessible(true);
-                            }
+                            field.setAccessible(true);
                             foundFields.add(field);
                         }
                     }
@@ -191,9 +189,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Method method : nextSource.getDeclaredMethods()) {
                         if (method.isAnnotationPresent(annotationClass)) {
-                            if (!method.isAccessible()) {
-                                method.setAccessible(true);
-                            }
+                            method.setAccessible(true);
                             foundMethods.add(method);
                         }
                     }
@@ -279,9 +275,7 @@ final class SecurityActions {
                 Class<?> nextSource = source;
                 while (nextSource != Object.class) {
                     for (Field field : nextSource.getDeclaredFields()) {
-                        if (!field.isAccessible()) {
-                            field.setAccessible(true);
-                        }
+                        field.setAccessible(true);
                         foundFields.add(field);
                     }
                     nextSource = nextSource.getSuperclass();

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/utils/AnnotationInvocationHandler.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/utils/AnnotationInvocationHandler.java
@@ -263,8 +263,7 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
 
     private static Object invoke(Method method, Object instance) {
         try {
-            if (!method.isAccessible())
-                method.setAccessible(true);
+            method.setAccessible(true);
             return method.invoke(instance);
         } catch (IllegalArgumentException e) {
             throw new RuntimeException("Error checking value of member method " + method.getName() + " on "

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/SecurityActions.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/SecurityActions.java
@@ -168,9 +168,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Field field : nextSource.getDeclaredFields()) {
                         if (field.isAnnotationPresent(annotationClass)) {
-                            if (!field.isAccessible()) {
-                                field.setAccessible(true);
-                            }
+                            field.setAccessible(true);
                             foundFields.add(field);
                         }
                     }
@@ -191,9 +189,7 @@ final class SecurityActions {
                 while (nextSource != Object.class) {
                     for (Method method : nextSource.getDeclaredMethods()) {
                         if (method.isAnnotationPresent(annotationClass)) {
-                            if (!method.isAccessible()) {
-                                method.setAccessible(true);
-                            }
+                            method.setAccessible(true);
                             foundMethods.add(method);
                         }
                     }
@@ -248,9 +244,7 @@ final class SecurityActions {
                 Class<?> nextSource = source;
                 while (nextSource != Object.class) {
                     for (Field field : nextSource.getDeclaredFields()) {
-                        if (!field.isAccessible()) {
-                            field.setAccessible(true);
-                        }
+                        field.setAccessible(true);
                         foundFields.add(field);
                     }
                     nextSource = nextSource.getSuperclass();


### PR DESCRIPTION
This tries to resolve one series of warnings from #218: `isAccessible` is deprecated since Java 9. The pull request is a "request for comments".

The current code uses it this way:
```
if (!field.isAccessible()) {
    field.setAccessible(true);
}
```

I think it is safe to remove the `isAccessible` call completely: when calling `setAccessible(boolean)`, a flag is set internally that switchs off the internal accessibility check. `AccessibleObject.isAccessible` (https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/reflect/AccessibleObject.html#isAccessible()) just returns this flag. So it is just a check whether the security override was called before. It is no check whether the field is private or not.

For a real check for public accessibility, `canAccess` would have to be called, which really checks whether a field is private. But this does not work in the context of warp, see sample at https://github.com/arquillian/arquillian-extension-warp/issues/218#issuecomment-2452950847. It would also require bigger rewrites of code, as it requires an instance of an object or null for static methods.

Currently, the calls to `isAccessible` always return `false` the first time they are invoked, so the following `setAccessible(true)` is invoked always. It would only have a (small?) performance impact if the code is executed again for the same AccessibilityObject.

`setAccessible(true)` might crash if the module system is enabled, but the Warp code would fail also without my change.



