### PR TITLE
Deprecation: replace newInstance

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/separation/SeparateInvocator.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/separation/SeparateInvocator.java
@@ -157,7 +157,7 @@ public class SeparateInvocator<T> {
     private Object instantiate() {
         try {
             separatedClass = loadSeparatedClassSafely(clazz);
-            return separatedClass.newInstance();
+            return separatedClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new IllegalStateException(
                 "Unable to instantiate class " + clazz.getName() + " on separated classloader", e);

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/transformation/InstanceCreator.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/transformation/InstanceCreator.java
@@ -25,7 +25,7 @@ public class InstanceCreator {
         Object instance = createUnsafeInstance(clazz);
         if(instance == null) {
             try {
-                instance = clazz.newInstance();
+                instance = clazz.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException("Could not create new instance of Transformed class: " + clazz.getName(), e);
             }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/shared/inspection/TestInspectionLoading.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/shared/inspection/TestInspectionLoading.java
@@ -137,7 +137,7 @@ public class TestInspectionLoading {
     private Object getStaticInnerClass() throws Throwable {
 
         Class<?> clazz = clientClassLoader.loadClass(SharingClass.class.getName());
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
         Method method = clazz.getMethod("getStaticInnerClass");
 
         // when
@@ -148,7 +148,7 @@ public class TestInspectionLoading {
     private Object getInnerClass() throws Throwable {
 
         Class<?> clazz = clientClassLoader.loadClass(SharingClass.class.getName());
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
         Method method = clazz.getMethod("getInnerClass");
 
         // when
@@ -159,7 +159,7 @@ public class TestInspectionLoading {
     private Object getAnonymousClass() throws Throwable {
 
         Class<?> clazz = clientClassLoader.loadClass(SharingClass.class.getName());
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
         Method method = clazz.getMethod("getAnonymousClass");
 
         // when

--- a/spi/src/main/java/org/jboss/arquillian/warp/spi/LifecycleManagerStore.java
+++ b/spi/src/main/java/org/jboss/arquillian/warp/spi/LifecycleManagerStore.java
@@ -138,7 +138,7 @@ public abstract class LifecycleManagerStore {
             if (resourceAsStream != null) {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(resourceAsStream));
                 String type = reader.readLine();
-                store = (LifecycleManagerStore) Class.forName(type).newInstance();
+                store = (LifecycleManagerStore) Class.forName(type).getDeclaredConstructor().newInstance();
                 INSTANCE.compareAndSet(null, store);
                 return INSTANCE.get();
             }


### PR DESCRIPTION
Another bunch of warnings from #218: `clazz.newInstance()` is deprecated since Java 9. 

It seems to be replaced by `clazz.getDeclaredConstructor().newInstance()`, see https://dev.devbf.com/posts/what-should-we-use-instead-of-classnewinstance-to-create-instances-now-ba6e0/