### PR TITLE
Deprecation: rework FacesContextFactory wrapping

### DIFF
--- a/extension/jsf/src/main/java/org/jboss/arquillian/warp/jsf/FacesContextFactory.java
+++ b/extension/jsf/src/main/java/org/jboss/arquillian/warp/jsf/FacesContextFactory.java
@@ -36,16 +36,15 @@ public class FacesContextFactory extends jakarta.faces.context.FacesContextFacto
 
     private Logger log = WarpJSFCommons.LOG;
 
-    private jakarta.faces.context.FacesContextFactory delegate;
-
     public FacesContextFactory(jakarta.faces.context.FacesContextFactory facesContextFactory) {
-        delegate = facesContextFactory;
+        super(facesContextFactory);
     }
 
+    @Override
     public FacesContext getFacesContext(Object context, Object request, Object response, Lifecycle lifecycle)
         throws FacesException {
 
-        FacesContext facesContext = delegate.getFacesContext(context, request, response, lifecycle);
+        FacesContext facesContext = getWrapped().getFacesContext(context, request, response, lifecycle);
 
         if (request instanceof HttpServletRequest) {
             HttpServletRequest httpReq = (HttpServletRequest) request;
@@ -78,15 +77,8 @@ public class FacesContextFactory extends jakarta.faces.context.FacesContextFacto
 
     public static class WarpFacesContext extends FacesContextWrapper {
 
-        private FacesContext wrapped;
-
         public WarpFacesContext(FacesContext wrapped) {
-            this.wrapped = wrapped;
-        }
-
-        @Override
-        public FacesContext getWrapped() {
-            return wrapped;
+          super(wrapped);
         }
 
         @Override


### PR DESCRIPTION
This is an attempt to fix two warnings from #218:

```
"The constructor FacesContextFactory() is deprecated" in /arquillian-warp-jsf/src/main/java/org/jboss/arquillian/warp/jsf/FacesContextFactory.java
"The constructor FacesContextWrapper() is deprecated" in /arquillian-warp-jsf/src/main/java/org/jboss/arquillian/warp/jsf/FacesContextFactory.java
```

As far as I understand it, `jakarta.faces.context.FacesContextFactory` and `jakarta.faces.context.FacesContextWrapper` already have the concept to wrap another factory/wrapper. The previous code did the same with an instance variable. So I removed this instance and forwarded the constructor argument to the base class.

The tests worked for me, so I hope my solution is correct.