### PR TITLE
Fix internal deprecation warnings, close ShrinkWrapClassLoader in tes…

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/utils/Base64.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/utils/Base64.java
@@ -457,6 +457,7 @@ public class Base64 extends BaseNCodec {
      *         <code>false</code>, otherwise
      * @deprecated 1.5 Use {@link #isBase64(byte[])}, will be removed in 2.0.
      */
+    @Deprecated
     public static boolean isArrayByteBase64(byte[] arrayOctet) {
         return isBase64(arrayOctet);
     }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestRequestExecutionSynchronization.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestRequestExecutionSynchronization.java
@@ -117,7 +117,7 @@ public class TestRequestExecutionSynchronization extends AbstractWarpClientTestT
     }
 
     @After
-    public void finalize() {
+    public void finalizeTest() {
         fire(new AfterClass(TestingClass.class));
     }
 

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/TestJavassistAndSeparatedClassLoader.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/TestJavassistAndSeparatedClassLoader.java
@@ -39,10 +39,8 @@ public class TestJavassistAndSeparatedClassLoader {
 
         JavaArchive archive = ShrinkWrap.create(JavaArchive.class).add(new CtClassAsset(ctClass));
 
-        ShrinkWrapClassLoader classLoader = new ShrinkWrapClassLoader(ClassLoaderUtils.getBootstrapClassLoader(), archive);
-
-        assertNotNull(classLoader.loadClass(CLASS_NAME));
-
-        classLoader.close();
+        try (ShrinkWrapClassLoader classLoader = new ShrinkWrapClassLoader(ClassLoaderUtils.getBootstrapClassLoader(), archive)) {
+            assertNotNull(classLoader.loadClass(CLASS_NAME));
+        }
     }
 }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/TestJavassistAndSeparatedClassLoader.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/TestJavassistAndSeparatedClassLoader.java
@@ -39,8 +39,10 @@ public class TestJavassistAndSeparatedClassLoader {
 
         JavaArchive archive = ShrinkWrap.create(JavaArchive.class).add(new CtClassAsset(ctClass));
 
-        ClassLoader classLoader = new ShrinkWrapClassLoader(ClassLoaderUtils.getBootstrapClassLoader(), archive);
+        ShrinkWrapClassLoader classLoader = new ShrinkWrapClassLoader(ClassLoaderUtils.getBootstrapClassLoader(), archive);
 
         assertNotNull(classLoader.loadClass(CLASS_NAME));
+
+        classLoader.close();
     }
 }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/utils/TestShrinkWrapUtils.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/utils/TestShrinkWrapUtils.java
@@ -35,7 +35,7 @@ public class TestShrinkWrapUtils {
     }
 
     @Test
-    public void testMultipleUse() throws ClassNotFoundException, IOException {
+    public void testMultipleUse() throws Exception {
         JavaArchive archive = ShrinkWrapUtils.getJavaArchiveFromClass(Test.class);
 
         try (ShrinkWrapClassLoader classLoader =

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/utils/TestShrinkWrapUtils.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/utils/TestShrinkWrapUtils.java
@@ -38,15 +38,14 @@ public class TestShrinkWrapUtils {
     public void testMultipleUse() throws ClassNotFoundException, IOException {
         JavaArchive archive = ShrinkWrapUtils.getJavaArchiveFromClass(Test.class);
 
-        ShrinkWrapClassLoader classLoader =
-            new ShrinkWrapClassLoader(ClassLoaderUtils.getBootstrapClassLoader(), archive);
-        Class<?> nestedClass = classLoader.loadClass(Test.class.getName());
+        try (ShrinkWrapClassLoader classLoader =
+            new ShrinkWrapClassLoader(ClassLoaderUtils.getBootstrapClassLoader(), archive)) {
+            Class<?> nestedClass = classLoader.loadClass(Test.class.getName());
 
-        JavaArchive nestedArchive = ShrinkWrapUtils.getJavaArchiveFromClass(nestedClass);
+            JavaArchive nestedArchive = ShrinkWrapUtils.getJavaArchiveFromClass(nestedClass);
 
-        assertNotNull(nestedArchive.get("/org/junit/Test.class"));
-        assertNotNull(nestedArchive.get("/org/junit/Ignore.class"));
-
-        classLoader.close();
+            assertNotNull(nestedArchive.get("/org/junit/Test.class"));
+            assertNotNull(nestedArchive.get("/org/junit/Ignore.class"));
+        }
     }
 }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/utils/TestShrinkWrapUtils.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/utils/TestShrinkWrapUtils.java
@@ -18,6 +18,8 @@ package org.jboss.arquillian.warp.impl.utils;
 
 import static org.junit.Assert.assertNotNull;
 
+import java.io.IOException;
+
 import org.jboss.shrinkwrap.api.classloader.ShrinkWrapClassLoader;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
@@ -33,7 +35,7 @@ public class TestShrinkWrapUtils {
     }
 
     @Test
-    public void testMultipleUse() throws ClassNotFoundException {
+    public void testMultipleUse() throws ClassNotFoundException, IOException {
         JavaArchive archive = ShrinkWrapUtils.getJavaArchiveFromClass(Test.class);
 
         ShrinkWrapClassLoader classLoader =
@@ -44,5 +46,7 @@ public class TestShrinkWrapUtils {
 
         assertNotNull(nestedArchive.get("/org/junit/Test.class"));
         assertNotNull(nestedArchive.get("/org/junit/Ignore.class"));
+
+        classLoader.close();
     }
 }

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/utils/TestShrinkWrapUtils.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/utils/TestShrinkWrapUtils.java
@@ -18,8 +18,6 @@ package org.jboss.arquillian.warp.impl.utils;
 
 import static org.junit.Assert.assertNotNull;
 
-import java.io.IOException;
-
 import org.jboss.shrinkwrap.api.classloader.ShrinkWrapClassLoader;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;


### PR DESCRIPTION
…t suite

This should be the finale step for #218: a maven build reports two more deprecation warnings that are not reported in Eclipse:

**Warning 1:**
`[WARNING] .../arquillian-extension-warp/impl/src/main/java/org/jboss/arquillian/warp/impl/utils/Base64.java:[460,27] deprecated item is not annotated with @Deprecated`

Resolution: add `@Deprecated` annotation also.

**Warning 2:**
[WARNING] /.../arquillian-extension-warp/impl/src/test/java/org/jboss/arquillian/warp/impl/client/execution/TestRequestExecutionSynchronization.java:[120,17] finalize() in java.lang.Object has been deprecated

See also https://stackoverflow.com/questions/56139760/why-is-the-finalize-method-deprecated-in-java-9
This seems to be just a wording issue, as the method is probably not meant to be a real finalizer. It also has the annotation `@After`, so it is executed after the test, not at the time when Java finalizes the object. So I renamed it to "finalizeTest".

**Closing ClassLoaders:**
This pull request also closes two ShrinkWrapClassLoader instances in the test suite - Eclipse complains:
`Resource leak: 'classLoader' is never closed` in TestJavassistAndSeparatedClassLoader.java
