### PR TITLE
Restore TestLifecycleManagerStore after JUnit5 migration

### DIFF
--- a/impl_test_separatecl/src/test/java/org/jboss/arquillian/warp/spi/TestLifecycleManagerStore.java
+++ b/impl_test_separatecl/src/test/java/org/jboss/arquillian/warp/spi/TestLifecycleManagerStore.java
@@ -21,11 +21,9 @@ import org.jboss.arquillian.warp.impl.testutils.SeparatedClassloaderExtension;
 import org.jboss.arquillian.warp.spi.exception.ObjectNotAssociatedException;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@Disabled("Disabled by https://github.com/arquillian/arquillian-extension-warp/pull/288 post JUnit5 migration")
 @ExtendWith(SeparatedClassloaderExtension.class)
 public class TestLifecycleManagerStore {
 


### PR DESCRIPTION
Resolves #291

It required two `changes:`
Part 1 is well known: in `SeparatedClassloaderLauncherSessionListener` add rules to the `filteringClassLoader` for all warp classes that are used by the test.

Part 2 was new to me: this test added a service provider file to the JavaArchive ("META-INF/services/org.jboss.arquillian.warp.spi.LifecycleManagerStore"), which pointed to the `TestingLifecycleManagerStore` used in this test. But while executing the test, the classloader loaded this resource from a different warp jar and thus picked the warp default `LifecycleManagerStoreImpl`, which failed to load. So the `filteringClassLoader ` also has to handle a lookup for this resource and forward it to the underlying `ShrinkWrapClassLoader`.