### PR TITLE
Java 17 deprecation: supppress AccessController deprecation warnings

### DIFF
--- a/extension/jsf/src/main/java/org/jboss/arquillian/warp/jsf/enricher/SecurityActions.java
+++ b/extension/jsf/src/main/java/org/jboss/arquillian/warp/jsf/enricher/SecurityActions.java
@@ -50,6 +50,7 @@ final class SecurityActions {
     /**
      * Obtains the Thread Context ClassLoader
      */
+    @SuppressWarnings("removal")
     static ClassLoader getThreadContextClassLoader() {
         return AccessController.doPrivileged(GetTcclAction.INSTANCE);
     }
@@ -143,6 +144,7 @@ final class SecurityActions {
      *
      * @throws NoSuchMethodException
      */
+    @SuppressWarnings("removal")
     static <T> Constructor<T> getConstructor(final Class<T> clazz, final Class<?>... argumentTypes)
         throws NoSuchMethodException {
         try {
@@ -181,6 +183,7 @@ final class SecurityActions {
      * @param value
      *     The new value
      */
+    @SuppressWarnings("removal")
     public static void setFieldValue(final Class<?> source, final Object target, final String fieldName,
         final Object value)
         throws NoSuchFieldException {
@@ -216,6 +219,7 @@ final class SecurityActions {
 
     public static List<Field> getFieldsWithAnnotation(final Class<?> source,
         final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
             public List<Field> run() {
                 List<Field> foundFields = new ArrayList<Field>();
@@ -237,6 +241,7 @@ final class SecurityActions {
 
     public static List<Method> getMethodsWithAnnotation(final Class<?> source,
         final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
             public List<Method> run() {
                 List<Method> foundMethods = new ArrayList<Method>();
@@ -258,6 +263,7 @@ final class SecurityActions {
 
     static String getProperty(final String key) {
         try {
+            @SuppressWarnings("removal")
             String value = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
                 public String run() {
                     return System.getProperty(key);

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/SecurityActions.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/execution/SecurityActions.java
@@ -59,6 +59,7 @@ final class SecurityActions {
     /**
      * Obtains the Thread Context ClassLoader
      */
+    @SuppressWarnings("removal")
     static ClassLoader getThreadContextClassLoader() {
         return AccessController.doPrivileged(GetTcclAction.INSTANCE);
     }
@@ -68,6 +69,7 @@ final class SecurityActions {
      *
      * @throws NoSuchMethodException
      */
+    @SuppressWarnings("removal")
     static Constructor<?> getConstructor(final Class<?> clazz, final Class<?>... argumentTypes)
         throws NoSuchMethodException {
         try {
@@ -159,6 +161,7 @@ final class SecurityActions {
     }
 
     static List<Field> getFieldsWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
             public List<Field> run() {
                 List<Field> foundFields = new ArrayList<Field>();
@@ -180,6 +183,7 @@ final class SecurityActions {
 
     static List<Method> getMethodsWithAnnotation(final Class<?> source,
         final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
             public List<Method> run() {
                 List<Method> foundMethods = new ArrayList<Method>();
@@ -236,6 +240,7 @@ final class SecurityActions {
     }
 
     static List<Field> getFields(final Class<?> source) {
+        @SuppressWarnings("removal")
         List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
             public List<Field> run() {
                 List<Field> foundFields = new ArrayList<Field>();

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/client/verification/SecurityActions.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/client/verification/SecurityActions.java
@@ -60,6 +60,7 @@ final class SecurityActions {
     /**
      * Obtains the Thread Context ClassLoader
      */
+    @SuppressWarnings("removal")
     static ClassLoader getThreadContextClassLoader() {
         return AccessController.doPrivileged(GetTcclAction.INSTANCE);
     }
@@ -69,6 +70,7 @@ final class SecurityActions {
      *
      * @throws NoSuchMethodException
      */
+    @SuppressWarnings("removal")
     static Constructor<?> getConstructor(final Class<?> clazz, final Class<?>... argumentTypes)
         throws NoSuchMethodException {
         try {
@@ -160,6 +162,7 @@ final class SecurityActions {
     }
 
     static List<Field> getFieldsWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
             public List<Field> run() {
                 List<Field> foundFields = new ArrayList<Field>();
@@ -180,6 +183,7 @@ final class SecurityActions {
     }
 
     static List<Method> getMethodsWithAnnotation(final Class<?> source) {
+        @SuppressWarnings("removal")
         List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
             public List<Method> run() {
                 List<Method> foundMethods = new ArrayList<Method>();
@@ -198,6 +202,7 @@ final class SecurityActions {
 
     static List<Method> getMethodsWithAnnotation(final Class<?> source,
         final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
             public List<Method> run() {
                 List<Method> foundMethods = new ArrayList<Method>();
@@ -254,6 +259,7 @@ final class SecurityActions {
     }
 
     static List<Field> getFields(final Class<?> source) {
+        @SuppressWarnings("removal")
         List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
             public List<Field> run() {
                 List<Field> foundFields = new ArrayList<Field>();

--- a/impl/src/main/java/org/jboss/arquillian/warp/impl/server/test/SecurityActions.java
+++ b/impl/src/main/java/org/jboss/arquillian/warp/impl/server/test/SecurityActions.java
@@ -60,6 +60,7 @@ final class SecurityActions {
     /**
      * Obtains the Thread Context ClassLoader
      */
+    @SuppressWarnings("removal")
     static ClassLoader getThreadContextClassLoader() {
         return AccessController.doPrivileged(GetTcclAction.INSTANCE);
     }
@@ -69,6 +70,7 @@ final class SecurityActions {
      *
      * @throws NoSuchMethodException
      */
+    @SuppressWarnings("removal")
     static Constructor<?> getConstructor(final Class<?> clazz, final Class<?>... argumentTypes)
         throws NoSuchMethodException {
         try {
@@ -160,6 +162,7 @@ final class SecurityActions {
     }
 
     static List<Field> getFieldsWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
             public List<Field> run() {
                 List<Field> foundFields = new ArrayList<Field>();
@@ -181,6 +184,7 @@ final class SecurityActions {
 
     static List<Method> getMethodsWithAnnotation(final Class<?> source,
         final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
             public List<Method> run() {
                 List<Method> foundMethods = new ArrayList<Method>();
@@ -268,6 +272,7 @@ final class SecurityActions {
     }
 
     static List<Field> getFields(final Class<?> source) {
+        @SuppressWarnings("removal")
         List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
             public List<Field> run() {
                 List<Field> foundFields = new ArrayList<Field>();

--- a/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/SecurityActions.java
+++ b/impl/src/test/java/org/jboss/arquillian/warp/impl/testutils/SecurityActions.java
@@ -60,6 +60,7 @@ final class SecurityActions {
     /**
      * Obtains the Thread Context ClassLoader
      */
+    @SuppressWarnings("removal")
     static ClassLoader getThreadContextClassLoader() {
         return AccessController.doPrivileged(GetTcclAction.INSTANCE);
     }
@@ -69,6 +70,7 @@ final class SecurityActions {
      *
      * @throws NoSuchMethodException
      */
+    @SuppressWarnings("removal")
     static Constructor<?> getConstructor(final Class<?> clazz, final Class<?>... argumentTypes)
         throws NoSuchMethodException {
         try {
@@ -160,6 +162,7 @@ final class SecurityActions {
     }
 
     static List<Field> getFieldsWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
             public List<Field> run() {
                 List<Field> foundFields = new ArrayList<Field>();
@@ -181,6 +184,7 @@ final class SecurityActions {
 
     static List<Method> getMethodsWithAnnotation(final Class<?> source,
         final Class<? extends Annotation> annotationClass) {
+        @SuppressWarnings("removal")
         List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
             public List<Method> run() {
                 List<Method> foundMethods = new ArrayList<Method>();
@@ -237,6 +241,7 @@ final class SecurityActions {
     }
 
     static List<Field> getFields(final Class<?> source) {
+        @SuppressWarnings("removal")
         List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
             public List<Field> run() {
                 List<Field> foundFields = new ArrayList<Field>();


### PR DESCRIPTION
`AccessController` is deprecated for removal since Java 17.

This is a followup to #317: the warnings are suppressed now.

Eclipse still reports false deprecation warnings in the editor (https://www.github.com/eclipse-jdt/eclipse.jdt.core/issues/3921), but not in the problems view. A maven build does not show them either. So I hope we are done here.