### PR TITLE
Testsuite: TomEE 10.1.1, Glassfish 7.0.25, WildFly 37.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,6 @@ jobs:
           - wildfly-managed
           - glassfish-managed
           - tomee-managed
-        exclude:
-          # TomEE does not launch on Java 24
-          # https://issues.apache.org/jira/browse/TOMEE-4474
-          - java: 24
-            container: tomee-managed
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/pom.xml
+++ b/pom.xml
@@ -98,13 +98,13 @@
     <modular.jdk.args />
 
     <!-- Container Versions -->
-    <version.tomee>10.1.0</version.tomee>
+    <version.tomee>10.1.1</version.tomee>
     <!-- Tomcat version bundled with TomEE - see https://tomee.apache.org/comparison.html
-         The version can be found in "bin/servlet-api.jar"
+         The version can be found in "lib/servlet-api.jar"
          It does not have to match exactly the version bundled with TomEE, but it should be at least the same JakartaEE spec version.-->
-    <version.tomee.tomcat>10.1.30</version.tomee.tomcat>
-    <version.glassfish>7.0.24</version.glassfish>
-    <version.wildfly>35.0.1.Final</version.wildfly>
+    <version.tomee.tomcat>10.1.44</version.tomee.tomcat>
+    <version.glassfish>7.0.25</version.glassfish>
+    <version.wildfly>37.0.1.Final</version.wildfly>
     <version.wildfly.arquillian.container>5.1.0.Beta11</version.wildfly.arquillian.container>
 
     <!-- Documentation -->


### PR DESCRIPTION
Update to TomEE 10.1.1 that restores compatibility with Java 24 (fixes #319). Thus we can remove the exclusion from CI test matrix.

Also updates Glassfish and WildFly to most recent versions.