### PR TITLE
Add Java 25 to testsuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         java:
           - 17
           - 21
-          - 24
+          - 25
         container:
           - wildfly-managed
           - glassfish-managed


### PR DESCRIPTION
Let's hope a Java 25 docker image already exists.