### PR TITLE
Aggregated Jacoco report for whole project

### DIFF
--- a/aggregate-jacoco-report/pom.xml
+++ b/aggregate-jacoco-report/pom.xml
@@ -1,0 +1,82 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss.arquillian.extension</groupId>
+    <artifactId>arquillian-warp-build</artifactId>
+    <version>2.1.0.Final-SNAPSHOT</version>
+    <relativePath>../build</relativePath>
+  </parent>
+
+  <artifactId>arquillian-warp-aggregate-jacoco-report</artifactId>
+  <name>Arquillian Warp: Aggregated Jacoco test coverage report</name>
+  <packaging>pom</packaging>
+  
+  <dependencies>
+    <!--Add all modules that should be part of the jacoco test coverage report -->
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-warp-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-warp-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-warp-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-warp-jsf</artifactId>
+    </dependency>
+
+    <!--Test projects-->
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-warp-impl-test-separatecl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-warp-ftest</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-warp-jsf-ftest</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+      <plugins>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <executions>
+            <!-- Disable executions "prepare-agent" und "report" defined in "build/pom.xml", as they are not required here. -->
+            <execution>
+              <id>prepare-agent</id>
+              <phase>none</phase>
+            </execution>
+            <execution>
+              <id>report</id>
+              <phase>none</phase>
+            </execution>
+            <!-- Instead, define the execution to aggregate the report -->
+            <execution>
+              <id>report-aggregate</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>report-aggregate</goal>
+            </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+  </build>
+</project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,6 +21,16 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
       </plugin>
+      <!--Create Jacoco report (required for report aggregation). This uses the default configuration from "build/pom.xml"-
+          Currently, this report is not required, as no unit tests are contained in this module.-->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <!--Jacoco related configuration inherited from "build/pom.xml"-->
+      </plugin>
     </plugins>
   </build>
 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -305,7 +305,8 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <argLine>${surefire.security.manager} ${modular.jdk.args}</argLine>
+            <!-- Prepend jacoco surefire args -->
+            <argLine>${surefire.jacoco.args} ${surefire.security.manager} ${modular.jdk.args}</argLine>
           </configuration>
         </plugin>
       </plugins>

--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -138,16 +138,16 @@
           </licenseSets>
         </configuration>
       </plugin>
+      <!--Create Jacoco report (mainly required for report aggregation). This uses the default configuration from "build/pom.xml".
+          The report in this project is also a "proof of concept" that a web project using "arquillian-extension-warp" can create
+          a Jacoco report for invocation of the server side of its classes. -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <!-- Prepend jacoco surefire args -->
-          <argLine>${surefire.jacoco.args} ${surefire.security.manager} ${modular.jdk.args}</argLine>
-        </configuration>
+        <!--Jacoco related configuration inherited from "build/pom.xml"-->
       </plugin>
     </plugins>
   </build>

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -126,16 +126,16 @@
           </licenseSets>
         </configuration>
       </plugin>
+      <!--Create Jacoco report (mainly required for report aggregation). This uses the default configuration from "build/pom.xml".
+          The report in this project is also a "proof of concept" that a web project using "arquillian-extension-warp" can create
+          a Jacoco report for invocation of the server side of its classes. -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <!-- Prepend jacoco surefire args -->
-          <argLine>${surefire.jacoco.args} ${surefire.security.manager} ${modular.jdk.args}</argLine>
-        </configuration>
+        <!--Jacoco related configuration inherited from "build/pom.xml"-->
       </plugin>
     </plugins>
   </build>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -132,6 +132,15 @@
           </licenseSets>
         </configuration>
       </plugin>
+      <!--Create Jacoco report (required for report aggregation). This uses the default configuration from "build/pom.xml"-->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <!--Jacoco related configuration inherited from "build/pom.xml"-->
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/impl_test_separatecl/pom.xml
+++ b/impl_test_separatecl/pom.xml
@@ -85,6 +85,15 @@
           </licenseSets>
         </configuration>
       </plugin>
+      <!--Create Jacoco report (required for report aggregation). This uses the default configuration from "build/pom.xml"-->
+	  <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <!--Jacoco related configuration inherited from "build/pom.xml"-->
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,9 @@
     <!-- extensions -->
     <module>extension/jsf</module>
     <module>extension/jsf-ftest</module>
+
+    <!--Jacoco report -->
+    <module>aggregate-jacoco-report</module>
   </modules>
 
   <build>


### PR DESCRIPTION
This is an attempt to resolve #230: I added a new project "aggregate-jacoco-report" that combines the Jacoco reports from the different projects.
It follows this sample: https://github.com/jacoco/jacoco/tree/master/jacoco-maven-plugin.test/it/it-report-aggregate
After running the build, the report can be found in ".../arquillian-extension-warp/aggregate-jacoco-report/target/site/jacoco-aggregate\index.html"

@rhusar Is this what you had in mind when creating the issue?

If yes: the next step could be to add them to the pull request as part of CI: https://github.com/marketplace/actions/jacoco-report or https://github.com/marketplace/actions/jacoco-badge-generator