### PR TITLE
Switch EL api dependency from JBoss fork to JakartaEE standard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
         versions: "[6.1.0,)"
       - dependency-name: jakarta.enterprise:jakarta.enterprise.cdi-api
         versions: "[4.1.0,)"
+      - dependency-name: jakarta.el:jakarta.el-api
+        versions: "[5.0.0,)"
       # Don't upgrade the tomcat servlet api, as it should match the TomEE version, which most probably does not contain a recent version of this artifact.
       - dependency-name: org.apache.tomcat:tomcat-servlet-api
         versions: "[10.1.0,)"

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -80,12 +80,12 @@
       <dependency>
         <groupId>jakarta.enterprise</groupId>
         <artifactId>jakarta.enterprise.cdi-api</artifactId>
-        <version>${version.jakarta.enterprise}</version>
+        <version>${version.jakarta.enterprise.jakarta-enterprise-cdi-api}</version>
       </dependency>
       <dependency>
-        <groupId>org.jboss.spec.jakarta.el</groupId>
-        <artifactId>jboss-el-api_5.0_spec</artifactId>
-        <version>${version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec}</version>
+        <groupId>jakarta.el</groupId>
+        <artifactId>jakarta.el-api</artifactId>
+        <version>${version.jakarta.el.jakarta-el-api}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.annotation</groupId>

--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -38,8 +38,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.jakarta.el</groupId>
-      <artifactId>jboss-el-api_5.0_spec</artifactId>
+      <groupId>jakarta.el</groupId>
+      <artifactId>jakarta.el-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/extension/jsf/pom.xml
+++ b/extension/jsf/pom.xml
@@ -30,8 +30,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.jakarta.el</groupId>
-      <artifactId>jboss-el-api_5.0_spec</artifactId>
+      <groupId>jakarta.el</groupId>
+      <artifactId>jakarta.el-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,10 +76,10 @@
 
     <!-- Jakarta EE 10 -->
     <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
-    <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>
+    <version.jakarta.enterprise.jakarta-enterprise-cdi-api>4.0.1</version.jakarta.enterprise.jakarta-enterprise-cdi-api>
     <version.jakarta.faces.jakarta-faces-api>4.0.1</version.jakarta.faces.jakarta-faces-api>
     <version.jakarta.servlet.jakarta-servlet-api>6.0.0</version.jakarta.servlet.jakarta-servlet-api>
-    <version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>4.0.1.Final</version.org.jboss.spec.jakarta.el.jboss-el-api_5.0_spec>
+    <version.jakarta.el.jakarta-el-api>5.0.0</version.jakarta.el.jakarta-el-api>
 
     <version.littleproxy>2.4.5</version.littleproxy>
     <!-- LittleProxy logging is done through SL4J and thus Log4j -->


### PR DESCRIPTION
While playing with JakartaEE 11 support, I noticed that the dependency "org.jboss.spec.jakarta.el:jboss-el-api_5.0_spec" has no JakartaEE 11 equivalent.
See https://repo.maven.apache.org/maven2/org/jboss/spec/jakarta/el/ and https://github.com/wildfly/jboss-jakarta-el-api_spec

So i switched it to the version from the JakartaEE standard, which is EL 6.0 - see https://repo.maven.apache.org/maven2/jakarta/el/jakarta.el-api/. As all Warp usages define it as "provided", it should have no effect at runtime.

I also renamed the property "version.jakarta.enterprise" to "version.jakarta.enterprise.jakarta-enterprise-cdi-api", following the name of other properties.