### PR TITLE
Testsuite: fix JUnit dependency definition so that dependabot can handle it

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -124,6 +124,8 @@
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>${version.junit}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- Mockito -->


### PR DESCRIPTION
Dependabot did not update JUnit for a long time, see e.g. latest run: https://github.com/arquillian/arquillian-extension-warp/actions/runs/18461577465/job/52594034679#step:3:1009


```
2025/10/13 09:41:07 [778] 404 https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.3.1/junit-bom-5.3.1.jar (cached)
  proxy | 2025/10/13 09:41:07 [780] HEAD https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.3.0/junit-bom-5.3.0.jar
2025/10/13 09:41:07 [780] 404 https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.3.0/junit-bom-5.3.0.jar (cached)
  proxy | 2025/10/13 09:41:08 [782] HEAD https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.2.0/junit-bom-5.2.0.jar
2025/10/13 09:41:08 [782] 404 https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.2.0/junit-bom-5.2.0.jar (cached)
updater | 2025/10/13 09:41:08 INFO <job_1123570991> Requirements to unlock update_not_possible
2025/10/13 09:41:08 INFO <job_1123570991> Requirements update strategy 
2025/10/13 09:41:08 INFO <job_1123570991> No update possible for org.junit:junit-bom 5.10.1
```

Dependabot requested jar files that don't exist and result in 404 errors. Hopefully this was caused by me not defining the "type":

```xml
      <dependency>
        <groupId>org.junit</groupId>
        <artifactId>junit-bom</artifactId>
        <version>${version.junit}</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
```

I did not update the dependency myself to test whether Dependabot can handle it after this was merged.

This is the followup to #355, which was broken.