### PR TITLE
Testsuite: define Junit dependency before shrinkwrap-resolver

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -21,6 +21,17 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- JUnit -->
+      <!-- Import before org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-bom, because otherwise the JUnit version from there is picked -->
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${version.junit}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- First declare the shrinkwrap-resolver bom to override version 2.2.6 pulled from elsewhere -->
       <!-- n.b. fixed by https://github.com/arquillian/arquillian-core/pull/575 - TODO move below post upgrade -->
       <dependency>
@@ -117,15 +128,6 @@
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
         <version>${version.httpcore}</version>
-      </dependency>
-
-      <!-- JUnit -->
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${version.junit}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <!-- Mockito -->


### PR DESCRIPTION
Found while testing the JUnit update to 6.0: `mvn dependency:tree` reported that another version than the configured one was used.

It should be 5.10.1 (current version) or 6.0.0 after applying the update from #357, but it was 5.10.3:
```
[INFO] --- dependency:3.8.1:tree (default-cli) @ arquillian-warp-api ---
[INFO] org.jboss.arquillian.extension:arquillian-warp-api:jar:2.1.0.Final-SNAPSHOT
[INFO] \- org.junit.jupiter:junit-jupiter:jar:5.10.3:test
[INFO]    +- org.junit.jupiter:junit-jupiter-api:jar:5.10.3:test
[INFO]    |  +- org.opentest4j:opentest4j:jar:1.3.0:test
[INFO]    |  +- org.junit.platform:junit-platform-commons:jar:1.10.3:test
[INFO]    |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO]    +- org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
[INFO]    \- org.junit.jupiter:junit-jupiter-engine:jar:5.10.3:test
[INFO]       \- org.junit.platform:junit-platform-engine:jar:1.10.3:test
```

It helped to move the dependency before `org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-bom`, somehow this one brings in an older JUnit version.