### PR TITLE
Testsuite: add dummy profile so that dependabot can detect server container updates

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -361,5 +361,32 @@
       </build>
     </profile>
 
+    <profile>
+      <!-- This profile is only used to enable dependabot so that it can detect and update the server containers
+           that are only declared as shrinkwrap resolver GAV coordinates and thus not readable by dependabot.
+           Don't use this profile for anything else.
+        -->
+      <id>dependabot-serverupdates</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.glassfish.main.distributions</groupId>
+          <artifactId>glassfish</artifactId>
+          <version>${version.glassfish}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-dist</artifactId>
+          <version>${version.wildfly}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.tomee</groupId>
+          <artifactId>apache-tomee</artifactId>
+          <version>${version.tomee}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This is an attempt to resolve #360.  After the pull request is merged, I will check the dependabot logs and see whether it can handle the server runtime updates.
Currently, there are no updates available for WildFly, TomEE or GlassFish. But WildFly 38.0.0 is pending.