### PR TITLE
Testsuite: fix dummy server dependencies to use type 'zip'

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -364,18 +364,21 @@
           <groupId>org.glassfish.main.distributions</groupId>
           <artifactId>glassfish</artifactId>
           <version>${version.glassfish}</version>
+          <type>zip</type>
           <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.wildfly</groupId>
           <artifactId>wildfly-dist</artifactId>
           <version>${version.wildfly}</version>
+          <type>zip</type>
           <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.tomee</groupId>
           <artifactId>apache-tomee</artifactId>
           <version>${version.tomee}</version>
+          <type>zip</type>
           <scope>provided</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Followup to #360: dependabot could not update GlassFish, as it used the default "type = jar", which does not exist in https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.25/

So switch to "type = zip" and hope that dependabot handles it properly.