### PR TITLE
Testsuite: add TomEE classifier to dummy server dependencies

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -379,6 +379,8 @@
           <artifactId>apache-tomee</artifactId>
           <version>${version.tomee}</version>
           <type>zip</type>
+          <!-- TomEE has several classifiers, so define the same that we use in the test suite -->
+          <classifier>webprofile</classifier>
           <scope>provided</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Third attempt to let dependabot update the server definitions (#360): TomEE failed because a maven artifact with `type=zip` does not exist, there are several classifiers in maven: https://repo.maven.apache.org/maven2/org/apache/tomee/apache-tomee/10.1.2/

Let's test whether Dependabot can also handle a classifier. It if does not work, I could set `type=pom`
