### PR TITLE
Attach Mockito as java agent to avoid java 25 warning

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -308,10 +308,24 @@
           </executions>
         </plugin>
         <plugin>
+          <!-- The dependency plugin is required for attaching Mockito as a java agent: the path to artifact "org.mockito:mockito-core:jar"
+               is written to a property by this goal, and this property value is used by the property "mockito.java.agent" -->
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <executions>
+            <execution>
+               <goals>
+                 <goal>properties</goal>
+               </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <!-- Prepend jacoco surefire args -->
-            <argLine>${surefire.jacoco.args} ${surefire.security.manager} ${modular.jdk.args}</argLine>
+            <!-- Prepend jacoco surefire args.
+                 Also activate the mockito java agent if the property value is set, see https://github.com/arquillian/arquillian-extension-warp/issues/341 -->
+            <argLine>${surefire.jacoco.args} ${surefire.security.manager} ${modular.jdk.args} ${mockito.java.agent}</argLine>
           </configuration>
         </plugin>
       </plugins>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -12,6 +12,12 @@
   <artifactId>arquillian-warp-impl</artifactId>
   <name>Arquillian Warp: Implementation</name>
 
+  <properties>
+    <!-- Attach mockito as java agent: define a property that is forwarded to the maven-surefire-plugin in parent pom.
+         The path to the mockito jar is taken from a property that is set by the maven-dependency-plugin (see parent pom) -->
+    <mockito.java.agent>-javaagent:${org.mockito:mockito-core:jar}</mockito.java.agent>
+  </properties>
+
   <dependencies>
 
     <!-- Warp -->
@@ -137,9 +143,15 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
+      <!--Enable the maven-dependency-plugin. This uses the default configuration from "build/pom.xml"-->
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <!--Jacoco related configuration inherited from "build/pom.xml"-->
+        <!--Jacoco and Mockito related configuration inherited from "build/pom.xml"-->
       </plugin>
     </plugins>
   </build>

--- a/impl_test_separatecl/pom.xml
+++ b/impl_test_separatecl/pom.xml
@@ -18,6 +18,10 @@
     <!-- Do NOT deploy any of the ITs module -->
     <maven.deploy.skip>true</maven.deploy.skip>
     <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+
+    <!-- Attach mockito as java agent: define a property that is forwarded to the maven-surefire-plugin in parent pom.
+         The path to the mockito jar is taken from a property that is set by the maven-dependency-plugin (see parent pom) -->
+    <mockito.java.agent>-javaagent:${org.mockito:mockito-core:jar}</mockito.java.agent>
   </properties>
 
   <dependencies>
@@ -92,9 +96,14 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
+      <!--Enable the maven-dependency-plugin. This uses the default configuration from "build/pom.xml"-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <!--Jacoco related configuration inherited from "build/pom.xml"-->
+        <!--Jacoco and Mockito related configuration inherited from "build/pom.xml"-->
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,11 @@
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.shrinkwrap.resolver>3.3.4</version.shrinkwrap.resolver>
     <version.jboss_spec>3.0.3.Final</version.jboss_spec>
+    <!-- Those properties build the java command line for the the maven-surefire-plugin, defined in "build/pom.xml".
+         Test projects or profiles might redefine them. -->
     <surefire.security.manager />
     <modular.jdk.args />
+    <mockito.java.agent />
 
     <!-- Container Versions -->
     <version.tomee>10.1.3</version.tomee>


### PR DESCRIPTION
This should fix the Java 25 warning from #341: mockito is now explicitly attached as java agent instead of using dynamic agent attaching.

Further details see https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3

I define an empty property "mockito.java.agent" in the root pom and fill it in "impl/pom.xml" and "impl_test_separatecl/pom.xml" with the value "-javaagent:${org.mockito:mockito-core:jar}". The property value "org.mockito:mockito-core:jar" is taken from a property that is set by the maven-dependency-plugin.
This plugin and the call of the goal "properties" is defined in "build/pom.xml". In "impl/pom.xml" and "impl_test_separatecl/pom.xml" the plugin is declared, but the config is taken from the parent pom.

I found another resolution without using maven-dependency-plugin: https://rieckpil.de/how-to-configure-mockito-agent-for-java-21-without-warning/ - I don't know which one is better ;-)