### PR TITLE
Testsuite: update JakartaEE 11 GlassFish to 8.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <version.tomee.tomcat>10.1.44</version.tomee.tomcat>
     <version.glassfish>7.1.0</version.glassfish>
     <!-- GlassFish 8 is used to test Jakarta EE 11 features -->
-    <version.glassfish8>8.0.0-M15</version.glassfish8>
+    <version.glassfish8>8.0.0</version.glassfish8>
     <version.wildfly>39.0.0.Final</version.wildfly>
     <version.wildfly.arquillian.container>5.1.0.Final</version.wildfly.arquillian.container>
 


### PR DESCRIPTION
Supersedes #393 and updates the correct version property.

@rhusar Do you have an idea how we could handle this?

We have two versions for the dependency "org.glassfish.main.distributions:glassfish". The one for JakartaEE 10 should not go beyond the latest version of the "7.x" branch, the other one could be updated to latest 8.0. 

Recently, I added  a profile so that dependabot also updates the server definitions, and this one now causes the trouble:
https://github.com/arquillian/arquillian-extension-warp/blob/7e5e9302d97a8caf3a955effbc2bfb15d63c65a1/build/ftest-base/pom.xml#L468-L470

I seems it is not possible to tell dependabot to update the constant "version.glassfish" to max 7.99 and "version.glassfish8" to full range?

A workaround could be to use "version.glassfish8" in the "dependabot-serverupdates" profile so that dependabot updates only the 8.x branch. The 7.x branch would remain untouched then, and we would have to check for updates ourselves (e.g whenever a GlassFish 8 update is notified). What do you think?