### PR TITLE
Testsuite: arquillian glassfish container 2.1.3: making asadmin executable is no longer necessary

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -23,8 +23,6 @@
     <arquillian.container.home />
     <arquillian.container.distribution />
     <arquillian.container.configuration />
-    <!-- Relative path to a file that should be made "executable" when the container is started by the arquillian container. -->
-    <arquillian.container.linux.executepermission.file />
     <arquillian.container.uninstall>true</arquillian.container.uninstall>
     <arquillian.container.vmargs>-Xmx768m -Darquillian.debug=${arquillian.debug}
     </arquillian.container.vmargs>
@@ -263,10 +261,6 @@
         <arquillian.container.home>${project.build.directory}/glassfish7</arquillian.container.home>
         <arquillian.container.distribution>org.glassfish.main.distributions:glassfish:zip:${version.glassfish}
         </arquillian.container.distribution>
-        <!-- Relative path to a file that should be made "executable" when the container is started by the arquillian container.
-             Here it is the "asadmin" script (https://github.com/OmniFish-EE/arquillian-container-glassfish/pull/9) -->
-        <arquillian.container.linux.executepermission.file>glassfish7/glassfish/bin/asadmin
-        </arquillian.container.linux.executepermission.file>
       </properties>
 
       <dependencies>
@@ -350,10 +344,6 @@
         <arquillian.container.home>${project.build.directory}/glassfish8</arquillian.container.home>
         <arquillian.container.distribution>org.glassfish.main.distributions:glassfish:zip:${version.glassfish8}
         </arquillian.container.distribution>
-        <!-- Relative path to a file that should be made "executable" when the container is started by the arquillian container.
-             Here it is the "asadmin" script (https://github.com/OmniFish-EE/arquillian-container-glassfish/pull/9) -->
-        <arquillian.container.linux.executepermission.file>glassfish8/glassfish/bin/asadmin
-        </arquillian.container.linux.executepermission.file>
       </properties>
 
       <dependencies>

--- a/build/resources/src/main/java/org/arquillian/warp/ftest/configuration/IntegrationTestConfiguration.java
+++ b/build/resources/src/main/java/org/arquillian/warp/ftest/configuration/IntegrationTestConfiguration.java
@@ -27,7 +27,6 @@ public class IntegrationTestConfiguration implements DroneConfiguration<Integrat
     private String containerHome;
     private String containerDistribution;
     private String containerConfiguration;
-    private String containerLinuxExecutePermissionFile;
     private Boolean containerUninstall;
     private Boolean debug;
 
@@ -52,16 +51,6 @@ public class IntegrationTestConfiguration implements DroneConfiguration<Integrat
      */
     public String getContainerHome() {
         return containerHome;
-    }
-
-    /**
-     * If the arquillian container adapter calls a launcher script for starting the container, this file must have the "execute" permisson on linux environments.
-     * This property must contain the relative path (subdir of "containerConfiguration").
-     *
-     * @return Relative path to the file that should be marked as "executable" if the test environment is not Windows.
-     */
-    public String getContainerLinuxExecutePermissionFile() {
-        return containerLinuxExecutePermissionFile;
     }
 
     /**

--- a/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInstaller.java
+++ b/build/resources/src/main/java/org/arquillian/warp/ftest/installation/ContainerInstaller.java
@@ -80,25 +80,6 @@ public class ContainerInstaller {
         log.info(String.format("The container distribution '%s' was installed into '%s'", distribution,
             unpackDestination.getAbsolutePath()));
 
-        // If we are running on a linux environment, maybe a launcher script that is required by the arquillian container plugin must be executable.
-        String launcherScript = configuration.get().getContainerLinuxExecutePermissionFile();
-        if (launcherScript != null && launcherScript.trim().length() > 0) {
-            // Do this only on non-Windows-OS.
-            if (!System.getProperty("os.name").toLowerCase().startsWith("windows")) {
-                File fileAsadmin = new File(unpackDestination.getAbsolutePath(), launcherScript);
-                if (fileAsadmin.exists()) {
-                    log.info(String.format("Preparing container: setting execute permisson for '%s'.", fileAsadmin.getAbsoluteFile()));
-                    fileAsadmin.setExecutable(true);
-                }
-                else {
-                    log.warning(String.format("Wrong configuration: Could not find file '%s'.", fileAsadmin.getAbsoluteFile()));
-                }
-            }
-            else {
-              log.info("Preparing container: No linux environment, skipping step.");
-            }
-        }
-
         if (!containerHome.exists()) {
             throw new IllegalStateException(String.format(
                 "The container distribution was unpacked but the containerHome (%s) still doesn't exist", containerHome));

--- a/build/resources/src/main/resources/arquillian.xml
+++ b/build/resources/src/main/resources/arquillian.xml
@@ -66,9 +66,6 @@
     <property name="containerConfiguration">${arquillian.container.configuration}</property>
     <!-- true if the container should be uninstalled after test when it was installed from distribution -->
     <property name="containerUninstall">${arquillian.container.uninstall}</property>
-    <!-- If the arquillian container adapter calls a launcher script for starting the container, this file must have the "execute" permisson on linux environments.
-         Configure the path relative to the subdir of "arquillian.container.configuration". -->
-    <property name="containerLinuxExecutePermissionFile">${arquillian.container.linux.executepermission.file}</property>
   </extension>
 
 </arquillian>


### PR DESCRIPTION
With the update of ee.omnifish.arquillian:arquillian-glassfish-server-managed from 2.1.2 to 2.1.3 in #413 I can revert part of #354 - the arquillian container now makes "asadmin" executable by itself (see https://www.github.com/OmniFish-EE/arquillian-container-glassfish/issues/29).