### PR TITLE
Testsuite: switch to SLF4J2 for e.g. LittleProxy logging

### DIFF
--- a/extension/jsf-ftest/pom.xml
+++ b/extension/jsf-ftest/pom.xml
@@ -115,10 +115,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <!--This binds to SLF4J 1.7.29 - same that is used up to LittleProxy 2.0.7.
-          More recent LittleProxy versions use "log4j-slf4j2-impl", but several other dependencies still provide the 1.x version, and
-          thus we would have to add a dependency "org.slf4:slf4j-api:2.0.7" to overwrite the other version. It is easier to stay with 1.x-->
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -105,10 +105,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <!--This binds to SLF4J 1.7.29 - same that is used up to LittleProxy 2.0.7.
-          More recent LittleProxy versions use "log4j-slf4j2-impl", but several other dependencies still provide the 1.x version, and
-          thus we would have to add a dependency "org.slf4:slf4j-api:2.0.7" to overwrite the other version. It is easier to stay with 1.x-->
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
LittleProxy logging uses SLF4J and prints a warning it this is not configured.

Ages ago I decided to use the old version SLF4J 1.7, with a hint that it might conflict with the version brought by other components. This conflict does not seem to exist any longer. So this pull requests moves on to `org.apache.logging.log4j:log4j-slf4j-impl` that brings `org.slf4j:slf4j-api:jar:2.0.17`.