### PR TITLE
Testsuite: WildFly 40 is Jakarta EE 11 by default and provides a Jakarta EE 10 fallback

### DIFF
--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -123,9 +123,9 @@
   <profiles>
 
     <!-- Containers -->
-
     <profile>
       <id>wildfly-managed</id>
+	  <!-- WildFly container for Jakarta EE 10 -->
       <activation>
         <activeByDefault>true</activeByDefault>
         <property>
@@ -135,8 +135,8 @@
       </activation>
       <properties>
         <arquillian.launch.wildfly>true</arquillian.launch.wildfly>
-        <arquillian.container.home>${project.build.directory}/wildfly-${version.wildfly}</arquillian.container.home>
-        <arquillian.container.distribution>org.wildfly:wildfly-dist:zip:${version.wildfly}
+        <arquillian.container.home>${project.build.directory}/wildfly-ee-10-${version.wildfly.jakartaee10}</arquillian.container.home>
+        <arquillian.container.distribution>org.wildfly:wildfly-ee-10-dist:zip:${version.wildfly.jakartaee10}
         </arquillian.container.distribution>
       </properties>
       <dependencies>
@@ -177,7 +177,7 @@
     </profile>
     <profile>
       <id>wildfly-jakartaee11-managed</id>
-      <!-- A WildFly Preview container which supports Jakarta EE 11.
+      <!-- A WildFly container which supports Jakarta EE 11.
            Run this profile only in combination with the profile "jakartaee11" so that arquillian-extension-warp is built using the JakartaEE11 api:
            mvn clean install -Pjakartaee11,wildfly-jakartaee11-managed
 	    -->
@@ -189,8 +189,8 @@
       </activation>
       <properties>
         <arquillian.launch.wildfly>true</arquillian.launch.wildfly>
-        <arquillian.container.home>${project.build.directory}/wildfly-preview-${version.wildfly}</arquillian.container.home>
-        <arquillian.container.distribution>org.wildfly:wildfly-preview-dist:zip:${version.wildfly}
+        <arquillian.container.home>${project.build.directory}/wildfly-${version.wildfly.jakartaee11}</arquillian.container.home>
+        <arquillian.container.distribution>org.wildfly:wildfly-dist:zip:${version.wildfly.jakartaee11}
         </arquillian.container.distribution>
       </properties>
       <dependencies>
@@ -443,7 +443,14 @@
         <dependency>
           <groupId>org.wildfly</groupId>
           <artifactId>wildfly-dist</artifactId>
-          <version>${version.wildfly}</version>
+          <version>${version.wildfly.jakartaee11}</version>
+          <type>zip</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-ee-10-dist</artifactId>
+          <version>${version.wildfly.jakartaee10}</version>
           <type>zip</type>
           <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,10 @@
     <version.glassfish8>8.0.1</version.glassfish8>
     <!-- GlassFish 7 supports Jakarta EE 10 -->	
     <version.glassfish>7.1.0</version.glassfish>
-    <version.wildfly>39.0.1.Final</version.wildfly>
+    <!-- Two different WildFly versions. Currently, WildFly 40 supports both Jakarta EE 10 and Jakarta EE 11, 
+         but a future WildFly version will remove Jakarta EE 10 support, so the two versions will differ. -->
+    <version.wildfly.jakartaee11>40.0.0.Final</version.wildfly.jakartaee11>
+    <version.wildfly.jakartaee10>40.0.0.Final</version.wildfly.jakartaee10>
     <version.wildfly.arquillian.container>5.1.0.Final</version.wildfly.arquillian.container>
 
     <!-- Documentation -->


### PR DESCRIPTION
This supersedes #428 and resolves #416

WildFly 40 is Jakarta EE 11 by default, so no need to use the [wildfly-preview](https://repo.maven.apache.org/maven2/org/wildfly/wildfly-preview-dist/) artifact.
As Warp by default uses Jakarta EE 10, the default "wildfly-managed" profile now uses the artifact [wildfly-ee-10-dist](https://repo.maven.apache.org/maven2/org/wildfly/wildfly-ee-10-dist/).
This alternative will be discontinued in one of the next few versions, so warp would have to stay with e.g. WildFly 41 for the Jakarta EE 10 profiles while the Jakarta EE 11 profile could move on.