### PR TITLE
Add Java 26 to CI test matrix, exclude GlassFish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,11 @@ jobs:
           - 17
           - 21
           - 25
+          - 26
         container:
+          # Build warp wíth the Jakarta EE 10 api and use the Jakarta EE 10 WildFly server:
           - wildfly-managed
-          # Build warp with the Jakarta EE 11 api and run it using the wildfly-preview server:
+          # Build warp with the Jakarta EE 11 api and run it using the default wildfly server:
           - jakartaee11,wildfly-jakartaee11-managed
           - glassfish-managed
           - tomee-managed
@@ -35,6 +37,11 @@ jobs:
         exclude:
           # GlassFish 8 does not support Java 17
           - java: 17
+            container: jakartaee11,glassfish-jakartaee11-managed
+          # GlassFish 7 and 8 do not support Java 26: https://github.com/eclipse-ee4j/glassfish/pull/25978
+          - java: 26
+            container: glassfish-managed
+          - java: 26
             container: jakartaee11,glassfish-jakartaee11-managed
     steps:
       - name: Checkout


### PR DESCRIPTION
GlassFish does not currently start with Java 26. There is a pull request for it, which waits for another component update: https://www.github.com/eclipse-ee4j/glassfish/pull/25978