### PR TITLE
Testsuite: add a profile for TomEE11M1 and JakartaEE11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           - tomee-managed
           # Build warp with the Jakarta EE 11 API and run it using the glassfish 8 server:
           - jakartaee11,glassfish-jakartaee11-managed
+          # Build warp with the Jakarta EE 11 API and run it using the TomEE 11 server:
+          - jakartaee11,tomee-jakartaee11-managed
         exclude:
           # GlassFish 8 does not support Java 17
           - java: 17

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -249,6 +249,48 @@
       </dependencies>
     </profile>
     <profile>
+      <!-- The TomEE 11 container supports JakartaEE11.
+           Run this profile only in combination with the profile "jakartaee11" so that arquillian-extension-warp is built using the JakartaEE11 api:
+           mvn clean install -Pjakartaee11,tomee-jakartaee11-managed
+	    -->
+      <id>tomee-jakartaee11-managed</id>
+      <activation>
+        <property>
+          <name>integration</name>
+          <value>tomee</value>
+        </property>
+      </activation>
+      <properties>
+        <arquillian.launch.tomee>true</arquillian.launch.tomee>
+        <arquillian.container.home>${project.build.directory}/apache-tomee-webprofile-${version.tomee.jakartaee11}
+        </arquillian.container.home>
+        <arquillian.container.distribution>org.apache.tomee:apache-tomee:zip:webprofile:${version.tomee.jakartaee11}
+        </arquillian.container.distribution>
+      </properties>
+      <dependencies>
+        <!--The dependency on the servlet api must be declared for each profile, see detailed explanation in the
+            test "org.jboss.arquillian.warp.jsf.ftest.lifecycle.TestFacesLifecycleFailurePropagation" in "jsf-ftest" project.
+
+            Also, it must be declared before "org.apache.tomee:arquillian-tomee-remote", because the latter brings "org.apache.tomee:jakartaee-api",
+            which also contains a "ServletException", but with a different SerialVersionUID. Thus the error described in "TestFacesLifecycleFailurePropagation"
+            would occur.
+            If we declare the servlet api jar before the arquillian jar, the ServletException class is loaded from there.
+          -->
+        <dependency>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-servlet-api</artifactId>
+          <scope>provided</scope>
+          <version>${version.tomee.jakartaee11.tomcat}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.tomee</groupId>
+          <artifactId>arquillian-tomee-remote</artifactId>
+          <version>${version.tomee.jakartaee11}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>glassfish-managed</id>
       <activation>
         <property>

--- a/build/ftest-base/pom.xml
+++ b/build/ftest-base/pom.xml
@@ -220,9 +220,9 @@
       </activation>
       <properties>
         <arquillian.launch.tomee>true</arquillian.launch.tomee>
-        <arquillian.container.home>${project.build.directory}/apache-tomee-webprofile-${version.tomee}
+        <arquillian.container.home>${project.build.directory}/apache-tomee-webprofile-${version.tomee.jakartaee10}
         </arquillian.container.home>
-        <arquillian.container.distribution>org.apache.tomee:apache-tomee:zip:webprofile:${version.tomee}
+        <arquillian.container.distribution>org.apache.tomee:apache-tomee:zip:webprofile:${version.tomee.jakartaee10}
         </arquillian.container.distribution>
       </properties>
       <dependencies>
@@ -238,12 +238,12 @@
           <groupId>org.apache.tomcat</groupId>
           <artifactId>tomcat-servlet-api</artifactId>
           <scope>provided</scope>
-          <version>${version.tomee.tomcat}</version>
+          <version>${version.tomee.jakartaee10.tomcat}</version>
         </dependency>
         <dependency>
           <groupId>org.apache.tomee</groupId>
           <artifactId>arquillian-tomee-remote</artifactId>
-          <version>${version.tomee}</version>
+          <version>${version.tomee.jakartaee10}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -499,7 +499,7 @@
         <dependency>
           <groupId>org.apache.tomee</groupId>
           <artifactId>apache-tomee</artifactId>
-          <version>${version.tomee}</version>
+          <version>${version.tomee.jakartaee10}</version>
           <type>zip</type>
           <!-- TomEE has several classifiers, so define the same that we use in the test suite -->
           <classifier>webprofile</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <!-- Tomcat version bundled with TomEE - see https://tomee.apache.org/comparison.html
          The version can be found in "lib/servlet-api.jar"
          It does not have to match exactly the version bundled with TomEE, but it should be at least the same JakartaEE spec version.-->
-    <version.tomee.tomcat>10.1.54</version.tomee.tomcat>
+    <version.tomee.jakartaee10.tomcat>10.1.54</version.tomee.jakartaee10.tomcat>
     <!-- TomEE 10 is used to test Jakarta EE 11 compatibility -->
     <version.tomee.jakartaee11>11.0.0-M1</version.tomee.jakartaee11>
     <version.tomee.jakartaee11.tomcat>11.0.22</version.tomee.jakartaee11.tomcat>

--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,16 @@
     <mockito.java.agent />
 
     <!-- Container Versions -->
-    <version.tomee>10.1.5</version.tomee>
+    <!-- TomEE 10 is used to test Jakarta EE 10 compatibility -->
+    <version.tomee.jakartaee10>10.1.5</version.tomee.jakartaee10>
     <!-- Tomcat version bundled with TomEE - see https://tomee.apache.org/comparison.html
          The version can be found in "lib/servlet-api.jar"
          It does not have to match exactly the version bundled with TomEE, but it should be at least the same JakartaEE spec version.-->
-    <version.tomee.tomcat>10.1.44</version.tomee.tomcat>
+    <version.tomee.tomcat>10.1.54</version.tomee.tomcat>
+    <!-- TomEE 10 is used to test Jakarta EE 11 compatibility -->
+    <version.tomee.jakartaee11>11.0.0-M1</version.tomee.jakartaee11>
+    <version.tomee.jakartaee11.tomcat>11.0.22</version.tomee.jakartaee11.tomcat>
+
     <!-- GlassFish 8 is used to test Jakarta EE 11 features -->
     <version.glassfish8>8.0.2</version.glassfish8>
     <!-- GlassFish 7 supports Jakarta EE 10 -->	


### PR DESCRIPTION
TomEE11M1 was recently released and brings support for JakartaEE11.

This pull request adds a new profile "tomee-jakartaee11-managed" that should be only used in combination with the JakartaEE11 profile.

Dependabot should only update the TomEE 10.x version, but not the 11 milestones.